### PR TITLE
Upgrade Spring Boot to 3.4.5, add comprehensive CI/CD and test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI – Build & Test
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build and run unit tests
+        run: mvn clean verify -P build -Dspring.profiles.active=build
+
+      - name: Upload Surefire reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: target/surefire-reports/
+          retention-days: 7
+
+      - name: Upload Failsafe / Karate reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: karate-reports
+          path: target/failsafe-reports/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,34 @@
+name: E2E – Karate Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  karate-e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run Karate E2E tests
+        run: mvn clean verify -Dspring.profiles.active=build
+
+      - name: Upload Karate HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: karate-html-report
+          path: target/karate-reports/
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release – Versioned SemVer Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 1.1.0)'
+        required: true
+        default: '1.1.0'
+      release_notes:
+        description: 'Short release notes'
+        required: false
+        default: 'Production-ready release after E2E green.'
+
+jobs:
+  # ─── Gate: E2E must pass before release ────────────────────────────────────
+  e2e-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run E2E gate
+        run: mvn clean verify -Dspring.profiles.active=build
+
+      - name: Upload Karate report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-karate-reports
+          path: target/karate-reports/
+          retention-days: 30
+
+  # ─── Publish release only when E2E passes ──────────────────────────────────
+  publish-release:
+    needs: e2e-gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build release JAR (skip tests – already passed in gate)
+        run: mvn clean package -DskipTests
+
+      - name: Create Git tag v${{ github.event.inputs.version }}
+        run: |
+          git config user.name  "GitHub Actions"
+          git config user.email "actions@github.com"
+          git tag -a "v${{ github.event.inputs.version }}" \
+                  -m "Release v${{ github.event.inputs.version }}: ${{ github.event.inputs.release_notes }}"
+          git push origin "v${{ github.event.inputs.version }}"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ github.event.inputs.version }}
+          name: "Release v${{ github.event.inputs.version }}"
+          body: |
+            ## Release v${{ github.event.inputs.version }}
+
+            **Notes:** ${{ github.event.inputs.release_notes }}
+
+            ### What's included
+            - Spring Boot 3.4.5 upgrade (Java 17)
+            - Karate E2E test suite
+            - GitHub Actions CI/CD
+            - REST-MCP Northstar roadmap
+
+            ### Verification
+            - ✅ All unit tests passed
+            - ✅ All Karate E2E tests passed
+          files: target/search-controller-*.jar

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,65 @@
-bin/
+# ─── Build output ─────────────────────────────────────────────────────────────
 target/
-.idea/
-.mymetadata
-.project
-.classpath
-.DS_Store
-.springBeans
-.settings/
-**/*.iml
-*.iml
-src/test/curl/.orchCurl_*
-src/test/curl/.Curl_tmp
+bin/
+out/
+
+# ─── Maven ────────────────────────────────────────────────────────────────────
 pom.xml.tag
 pom.xml.releaseBackup
+pom.xml.versionsBackup
 pom.xml.next
 release.properties
-**/*.ami
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
 
+# ─── IDE – IntelliJ ───────────────────────────────────────────────────────────
+.idea/
+*.iml
+*.ipr
+*.iws
 
+# ─── IDE – Eclipse / STS ──────────────────────────────────────────────────────
+.project
+.classpath
+.settings/
+.springBeans
+.mymetadata
+*.launch
+*.factorypath
+
+# ─── IDE – VS Code ────────────────────────────────────────────────────────────
+.vscode/
+*.code-workspace
+
+# ─── AI tooling ───────────────────────────────────────────────────────────────
+.qodo/
+.copilot/
+
+# ─── OS ───────────────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# ─── Logs ─────────────────────────────────────────────────────────────────────
+*.log
+logs/
+/tmp/
+
+# ─── Environment / secrets ────────────────────────────────────────────────────
+.env
+.env.*
+!.env.example
+*.local
+
+# ─── Test artefacts ───────────────────────────────────────────────────────────
+src/test/curl/.orchCurl_*
+src/test/curl/.Curl_tmp
+
+# ─── Redis dump ───────────────────────────────────────────────────────────────
+dump.rdb
+
+# ─── Windows crash dumps ──────────────────────────────────────────────────────
 bash.exe.stackdump
 sh.exe.stackdump
-dump.rdb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,162 @@
+# AGENTS.md – RedisCache-SpringBoot
+
+Agent instructions for AI assistants working in this repo. Read this before making changes.
+
+---
+
+## What This Repo Is
+
+Sample Spring Boot 3.4.5 + Redis cache service demonstrating the **Walmart Turing** pattern:
+turn any backend REST repo into an MCP-capable service so AI agents can call it directly
+via the Model Context Protocol — without breaking existing REST consumers.
+
+Current state: REST baseline is production-ready (v1.1.0). Active work is Phase 1 of the
+REST-MCP bridge (see `docs/REST-MCP-ROADMAP.md`).
+
+---
+
+## Quick Navigation
+
+| Need                                   | Go here                    |
+|----------------------------------------|----------------------------|
+| Endpoint contracts + DTO map           | `docs/CURRENT-STATE.md`    |
+| MCP phases 1-4 detail                  | `docs/REST-MCP-ROADMAP.md` |
+| Full requirement + acceptance criteria | `one-requirement.md`       |
+| CI pipeline config                     | `.github/workflows/`       |
+
+---
+
+## Build & Test Commands
+
+```bash
+# Unit tests (no Redis required — uses in-memory cache)
+mvn clean test -Dspring.profiles.active=build
+
+# E2E / Karate (starts embedded server, runs feature files)
+mvn clean verify -Dspring.profiles.active=build
+
+# Run app locally (no Redis)
+./SpringBootRunner.sh
+
+# Package without running tests
+mvn clean package -DskipTests
+```
+
+All test commands must stay green before merging. Never skip `-Dspring.profiles.active=build`
+for local runs — without it the app tries to connect to a real Redis instance.
+
+---
+
+## Endpoint Matrix
+
+| Method | Path                       | Controller         | Service method        | Notes                                   |
+|--------|----------------------------|--------------------|-----------------------|-----------------------------------------|
+| POST   | `/Account/{accountNumber}` | `DataController`   | `addDataToCache`      | Idempotent — no-op if key exists        |
+| PATCH  | `/Account/{accountNumber}` | `DataController`   | `updateDataInCache`   | Actions: `Credit`, `Withdraw`, `Remove` |
+| DELETE | `/Account/{accountNumber}` | `DataController`   | `removeDataFromCache` | Evicts key; no-op if missing            |
+| POST   | `/`                        | `SearchController` | `search`              | Cache miss returns zeroed `Result`      |
+| GET    | `/actuator/health`         | Spring Actuator    | —                     | Always UP in build profile              |
+
+---
+
+## DTO Contracts
+
+| Class       | Package | Fields                                                     | Used as             |
+|-------------|---------|------------------------------------------------------------|---------------------|
+| `CacheData` | `api`   | `type: String`, `value: String @NotBlank`                  | POST /Account body  |
+| `PatchData` | `api`   | `action: String @NotBlank`, `value: Long`                  | PATCH /Account body |
+| `Request`   | `api`   | `account: String`                                          | POST / body         |
+| `Result`    | `api`   | `account`, `type`, `value`, `lastModification`             | Search response     |
+| `CacheInfo` | root    | `accoutnNumber` (sic), `type`, `value`, `lastModification` | Stored in cache     |
+
+> `CacheInfo.accoutnNumber` is a known typo — **do not rename** (breaks serialized cache entries).
+
+---
+
+## Key Source Layout
+
+```
+src/main/java/com/search/
+├── api/
+│   ├── DataController.java      ← POST/PATCH/DELETE /Account/{n}
+│   ├── SearchController.java    ← POST /
+│   ├── DataService.java         ← write interface
+│   ├── Service.java             ← search interface
+│   ├── CacheData.java / PatchData.java / Request.java / Result.java
+├── config/
+│   ├── CacheConfig.java         ← profile-switched cache bean factory
+│   ├── BuildCacheConfig.java    ← ConcurrentMapCache (build/test profile)
+│   ├── RedisCacheConfig.java    ← JedisConnectionFactory (prod profile)
+├── CacheService.java            ← implements DataService + Service
+├── SearchService.java           ← thin search façade (delegates to CacheService)
+└── SearchApplication.java
+```
+
+---
+
+## When You Add a New Endpoint
+
+1. Add the method to the relevant interface (`DataService` or `Service`) first.
+2. Implement in `CacheService` — keep each cache operation ≤ 30 lines.
+3. Wire in the controller; keep controllers free of business logic.
+4. Add a `@Valid` DTO if the endpoint takes a request body.
+5. Write a unit test in `src/test/.../api/<Controller>Test.java`.
+6. Add or extend a Karate `.feature` file in `src/test/resources/karate/`.
+7. Run `mvn clean verify -Dspring.profiles.active=build` before pushing.
+
+---
+
+## When You Expose a Service Method as an MCP Tool (Turing Pattern)
+
+This is the active Phase 1 work. Follow the pattern in `docs/REST-MCP-ROADMAP.md`:
+
+1. **Read-only first.** Start with `searchAccount` / `getAccountBalance` — no auth needed.
+2. **Adapter class** goes in `src/main/java/com/search/mcp/` (create the package).
+3. **Never modify existing service signatures.** The MCP adapter calls services; services
+   do not know about MCP.
+4. **Tool schema** must have: `name` (camelCase), `description` (≥ 1 sentence), `inputSchema`
+   matching the service method parameters.
+5. **Contract test required** — add an MCP client integration test alongside unit tests.
+6. **REST endpoint stays unchanged** — verify with existing Karate suite after adding MCP layer.
+
+Recommended SDK: `io.modelcontextprotocol:sdk` (pinned version). See roadmap Phase 2 task list
+for dependency coordinates.
+
+---
+
+## Test Conventions
+
+- Unit tests: `src/test/.../` matching the source package, suffix `Test.java`.
+- Karate E2E: `src/test/resources/karate/*.feature` — one feature file per endpoint group.
+- Test profile activates `BuildCacheConfig` (in-memory) — no Redis, no Docker required.
+- Mock with `@MockitoBean` (Spring Boot 3.4+) not `@MockBean`.
+- Assert **outcomes** (response body, status code, cache state) — not method invocations.
+
+---
+
+## Commit & Branch Conventions
+
+```
+feat: <what>          # new capability
+fix: <what>           # bug fix
+refactor: <what>      # no behavior change
+test: <what>          # test-only change
+docs: <what>          # docs-only change
+mcp: <what>           # MCP adapter / tool work (Phase 1+)
+```
+
+Branch naming: `feature/<ticket>-<slug>`, `fix/<ticket>-<slug>`, `mcp/phase-<n>-<slug>`.
+
+---
+
+## Runbooks
+
+Markdown runbooks in `docs/runbooks/` — usable by any developer, AI agent, or CLI tool.
+
+| Runbook                  | What it does                                                                     |
+|--------------------------|----------------------------------------------------------------------------------|
+| `scaffold-mcp-tool.md`   | Generate `@Tool` wrapper + schema + contract test for a service method           |
+| `add-endpoint.md`        | Scaffold controller + DTO + unit test + Karate feature (this repo's conventions) |
+| `run-karate.md`          | Run Karate E2E suite and summarize pass/fail by scenario                         |
+| `endpoint-smoke-test.md` | Curl all endpoints against the running local app and report status               |
+| `release-gate-check.md`  | Verify E2E green, tag checklist, and prepare release notes                       |

--- a/README.md
+++ b/README.md
@@ -1,128 +1,98 @@
-# Spring Boot "Redis Cache" Example Project for proof of concept
+# RedisCache-SpringBoot
 
-This is a sample Java / Maven / Spring Boot (version 2.2.2) application that can be used as a starter for creating a microservice complete with built-in health check, metrics and much more.
-I hope it helps you.
+Spring Boot 3.4.5 + Redis cache service — modernized REST API with CI/CD and a REST-MCP Northstar roadmap.
 
-## Description about application
-* In application there is a concept of CacheManager and CacheFactory to store the data and manage the Redis cache for that you can find Config package where required Beans is created and maintained.
-* For Managing Bucket ( So called Database table for Cache ) is configured in CacheConfig In current project there is only one bucket used ACCOUNT_CACHE.
-* For storing data in Bucket Redis use Cache key concept ( So called primary key or Identifier ) this application generate cache key like ```ACCOUNT_1234```
-* And whenever Search account called will retrieve the cacheKey if its available then read the data stored on that cacheKey and pass it to response to postman or person who requested for it.
+> **Current version:** `1.1.0` &nbsp;|&nbsp; **Java:** 17 &nbsp;|&nbsp; **Profile:** `build` (in-memory cache, no Redis
+> needed for tests)
 
-## How to Run
-This application is spring boot it is packaged as a war which has Tomcat 8 embedded. No Tomcat or JBoss installation is necessary. You run it using the java -jar command.
+---
 
-* Clone this repository
-* Make sure you are using JDK 1.8 and Maven 3.x
-* You can build the project and run the tests by running ```mvn clean install```
-* Once successfully built, you can run the service by one of these two methods:
+## Quick Start
 
-One give main file "SearchApplication.java" to your IDE (Intellij or Eclipse) for run it, it will run automatically.
-Second is run shell scripts Name as SpringBootRunner.sh Scripts have commands as below.
+```bash
+# No Redis required — uses in-memory cache
+./SpringBootRunner.sh
+
+# Unit tests
+mvn clean test -Dspring.profiles.active=build
+
+# Full E2E (Karate)
+mvn clean verify -Dspring.profiles.active=build
 ```
-#!/bin/sh
-
-# For debugging, create a remote run configuration using port 3000
-
-export DEBUG_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -DDEBUG -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=3000"
-export JAVA_OPTS="-Xms512M -Xmx512M -Xmn128M -Xverify:none -Xshare:off"
-export MAVEN_OPTS="-Xmx1024M  ${DEBUG_OPTS} ${JAVA_OPTS}"
-
-mvn spring-boot:run 
--Dcatalina.base=target/tomcat \
-```
-
-Run it anyway but don't forget to turn on your Redis Cache server in your local,
-* There is a Redis Cache Server Installation steps on this link please refer that to install in your computer/system - ```https://redis.io/download```
 
 ## About the Service
 
-The service is just a simple Redis cache REST service. It uses an Redis cache database to store the data and it have a time to live configured for one hour. you can call some REST endpoints defined in ```com.search.api.SearchController``` or ```com.search.api.DataController``` on **port 8080**. (see below)
+In-memory / Redis-backed cache for account data. Uses `CacheManager` (profile-switched: in-memory for `build`, Jedis for
+production) to manage an `AccountCache` bucket with 1-hour TTL.
 
-More interestingly, you can start calling some of the operational endpoints (see full list below) like ```/Account``` and ```/``` (these are available on **port 8080**)
+### Endpoints
 
-You can use this sample service to understand the conventions and configurations that allow you to create a Redis Cache Server and bucket for store the data to RESTful service. Once you understand and get comfortable with the sample app /proof of concept you can add/extend modify as your own services (as your your own project needs).
+| Method | Path                       | Description                                       |
+|--------|----------------------------|---------------------------------------------------|
+| POST   | `/Account/{accountNumber}` | Add account to cache                              |
+| PATCH  | `/Account/{accountNumber}` | Update account (`Credit` / `Withdraw` / `Remove`) |
+| DELETE | `/Account/{accountNumber}` | Evict account from cache                          |
+| POST   | `/`                        | Search account by number                          |
+| GET    | `/actuator/health`         | Health check                                      |
 
-Here is what this little application demonstrates:
-
-* Full integration with the latest **Spring** Framework: inversion of control, dependency injection, etc.
-* Packaging as a single war with embedded container (tomcat 8): No need to install a container separately on the host just run using the ``java -jar`` command
-* Demonstrates how to set up PUT, PATCH, DELETE and POST EndPoints for Managing data in Redis Cache Bucket. endpoints automatically on a configured port.
-* Writing a RESTful service using annotation: supports JSON request / response; simply use desired ``Content-Type:application/json`` header in your request
-* Exception mapping from application exceptions to the right HTTP response with exception details in the body
-* All APIs are currently not documented I'll add some in future with swagger.
-
-Here are some endpoints you can call:
-
-### Get information about system health, configurations, etc.
+### Add account
 
 ```
-http://localhost:8080/Account/{AccountNumber}
-http://localhost:8080/
+POST /Account/1234
+Content-Type: application/json
+
+{ "type": "Saving", "value": "100" }
+
+→ 200  "Account 1234 Added into Data"
 ```
 
-### Retrieve list of Account/ Entry in Redis cache Bucket
+### Search account
 
 ```
 POST /
 Content-Type: application/json
 
-{
-"account" : "1234"
-}
+{ "account": "1234" }
 
-RESPONSE: HTTP 201 (Created)
-Location header: http://localhost:8080/
-
+→ 200
 {
-"account": 1234,
-"type": "Saving",
-"value": 555,
-"lastModification": "2019-12-20T02:40:24.312Z"
+  "account": 1234,
+  "type": "Saving",
+  "value": 100,
+  "lastModification": "2024-12-20T02:40:24.312Z"
 }
 ```
 
-###  Create a Account/ Entry in Redis Cache Bucket
+### Update (Credit / Withdraw)
 
 ```
-String accountNumber = 1234
-POST /Account/{accountNumber}
+PATCH /Account/1234
 Content-Type: application/json
 
-{
-"type":"Saving",
-"value":"100"
-}
+{ "action": "Credit", "value": 200 }
 
-Response: HTTP 200
-Content: "Account 1234 Added into Data"
+→ 200  "Account 1234 is updated"
 ```
 
-### Update a Account/ Entry in Redis Cache Bucket
+### Delete
 
 ```
-String accountNumber = 1234
-PATCH /Account/{accountNumber}
-Content-Type: application/json
+DELETE /Account/1234
 
-{
-"action":"add",
-"value":"200"
-}
-
-RESPONSE: HTTP 200
-Content "Account 1234 is updated"
+→ 200  "Removed Account 1234"
 ```
 
-### Remove a Account/ Entry in Redis Cache Bucket
+---
 
-```
-String accountNumber = 1234
-DELETE /Account/{accountNumber}
-Content-Type: application/json
+## Architecture
 
-RESPONSE: HTTP 200
-Content "Removed account 1234"
-```
+See `AGENTS.md` for full source layout, conventions, and MCP roadmap guidance.  
+See `docs/REST-MCP-ROADMAP.md` for the phased plan toward REST-MCP bridge.
 
-# Questions and Comments : skullfox@hackermail.com
+## Prerequisites (production with Redis)
+
+- Java 17+
+- Maven 3.8+
+- Redis 7+ on `localhost:6379` (only needed for `redis` profile)
+
+Contact: skullfox@hackermail.com

--- a/SpringBootRunner.sh
+++ b/SpringBootRunner.sh
@@ -1,10 +1,42 @@
-#!/bin/sh
+#!/usr/bin/env bash
+# =============================================================================
+# SpringBootRunner.sh – local development startup script
+#
+# Prerequisites:
+#   - Java 17+  (check: java -version)
+#   - Maven 3.8+ (check: mvn -version)
+#   - Redis running on localhost:6379  *only* when using the 'redis' profile
+#     (default profile is 'build' which uses in-memory cache – no Redis needed)
+#
+# Usage:
+#   ./SpringBootRunner.sh                     # default build profile (no Redis)
+#   SPRING_PROFILES_ACTIVE=redis ./SpringBootRunner.sh   # real Redis
+# =============================================================================
 
-# For debugging, create a remote run configuration using port 3000
+set -euo pipefail
 
-export DEBUG_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -DDEBUG -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=3000"
-export JAVA_OPTS="-Xms512M -Xmx512M -Xmn128M -Xverify:none -Xshare:off"
-export MAVEN_OPTS="-Xmx1024M  ${DEBUG_OPTS} ${JAVA_OPTS}"
+PROFILE="${SPRING_PROFILES_ACTIVE:-build}"
+APP_PORT="${SERVER_PORT:-8080}"
 
-mvn spring-boot:run
--Dcatalina.base=target/tomcat \
+echo "=================================================="
+echo "  RedisCache-SpringBoot  |  profile=${PROFILE}  |  port=${APP_PORT}"
+echo "=================================================="
+
+# Verify Java 17+
+JAVA_MAJOR=$(java -version 2>&1 | awk -F '"' '/version/ {print $2}' | cut -d'.' -f1)
+if [[ "${JAVA_MAJOR}" -lt 17 ]]; then
+  echo "ERROR: Java 17+ is required (found major version ${JAVA_MAJOR})."
+  exit 1
+fi
+
+export MAVEN_OPTS="-Xmx512m -Xms256m"
+
+echo "Building project..."
+mvn clean package -DskipTests -q
+
+echo "Starting application on port ${APP_PORT} with profile '${PROFILE}'..."
+java -jar \
+  -Dspring.profiles.active="${PROFILE}" \
+  -Dserver.port="${APP_PORT}" \
+  target/search-controller-1.1.0.jar
+

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -1,0 +1,56 @@
+# Current State Notes
+
+## Project Overview
+
+Spring Boot REST API backed by Redis (Jedis) for in-memory caching of account data.
+
+## Endpoint Inventory
+
+| Method | Path                       | Controller         | Description                             |
+|--------|----------------------------|--------------------|-----------------------------------------|
+| POST   | `/Account/{accountNumber}` | `DataController`   | Add account data to cache               |
+| PATCH  | `/Account/{accountNumber}` | `DataController`   | Update account (Credit/Withdraw/Remove) |
+| DELETE | `/Account/{accountNumber}` | `DataController`   | Remove account from cache               |
+| POST   | `/`                        | `SearchController` | Search cache by account number          |
+| GET    | `/actuator/health`         | Spring Actuator    | Health check                            |
+
+## DTO Map
+
+| Class       | Role                                                             |
+|-------------|------------------------------------------------------------------|
+| `CacheData` | POST request body – `type` (String), `value` (String, required)  |
+| `PatchData` | PATCH request body – `action` (String, required), `value` (Long) |
+| `Request`   | Search request – `account` (String)                              |
+| `Result`    | Search response – `account`, `type`, `value`, `lastModification` |
+| `CacheInfo` | Internal cache object stored under key `Account_{number}`        |
+
+## Cache Flows
+
+- **Write** (`addDataToCache`): only writes if key does not exist (idempotent add)
+- **Credit** (`updateDataInCache`): adds to stored value
+- **Withdraw**: subtracts; floor at current value if result < 0
+- **Remove** (PATCH action): evicts key
+- **Delete** endpoint: evicts key directly
+- **Search**: cache miss returns empty `Result` (zero/null fields)
+
+## Build / Run
+
+```bash
+# Local (no Redis, uses in-memory ConcurrentMap):
+./SpringBootRunner.sh
+
+# Unit tests:
+mvn clean test -Dspring.profiles.active=build
+
+# E2E (Karate):
+mvn clean verify -Dspring.profiles.active=build
+```
+
+## Known Issues Fixed in v1.1.0
+
+- Upgraded from Spring Boot 2.2.2 → 3.4.5 (Java 17)
+- Migrated `javax.validation` → `jakarta.validation`
+- Fixed malformed `SpringBootRunner.sh` (dangling backslash)
+- Updated `spring.redis.*` → `spring.data.redis.*` properties
+- Changed WAR → JAR packaging
+- Added test infrastructure (JUnit 5 + Karate)

--- a/docs/runbooks/add-endpoint.md
+++ b/docs/runbooks/add-endpoint.md
@@ -1,0 +1,58 @@
+You are adding a new REST endpoint to the RedisCache-SpringBoot service.
+Follow the existing patterns exactly — do not introduce new frameworks or abstractions.
+
+## What you need from the user (ask if not provided)
+
+- **HTTP method** (GET / POST / PATCH / DELETE)
+- **Path** (e.g., `/Account/{accountNumber}/balance`)
+- **What it does** (brief description)
+- **Request body shape** (if any)
+- **Response shape**
+
+## Steps to execute
+
+1. **Read** `AGENTS.md` (endpoint matrix + conventions) and `docs/CURRENT-STATE.md` (DTO map).
+2. **Read** the most similar existing controller and service files to match the pattern:
+    - `src/main/java/com/search/api/DataController.java`
+    - `src/main/java/com/search/CacheService.java`
+
+3. **DTO** (if new request/response shape is needed):
+    - Create in `src/main/java/com/search/api/`
+    - Use Lombok `@Data` + `@NoArgsConstructor`
+    - Validate inputs with `jakarta.validation` annotations (`@NotBlank`, `@NotNull`)
+    - Keep DTOs as simple POJOs — no service logic
+
+4. **Service interface** — add the method signature to `DataService.java` or `Service.java`
+   (whichever matches the operation type: write vs. search).
+
+5. **Service implementation** in `CacheService.java`:
+    - Keep the implementation ≤ 30 lines
+    - Follow existing cache key convention: `"Account_" + accountNumber`
+    - Handle null/missing cache entries gracefully (return empty/default, not exception)
+
+6. **Controller method** in the appropriate controller:
+    - Use `@Valid` on `@RequestBody` params
+    - Return `ResponseEntity<?>` for write operations, typed response for reads
+    - No business logic — delegate to service immediately
+
+7. **Unit test** in `src/test/java/com/search/api/<Controller>Test.java`:
+    - Test happy path (2xx) and at least one error path (4xx or missing key)
+    - Use `MockMvc` + `@MockitoBean` (not `@MockBean`)
+    - Assert response status AND body — not just that the service was called
+
+8. **Karate scenario** — add to the most relevant feature file in
+   `src/test/resources/karate/` (or create a new `.feature` if it's a distinct domain):
+    - Scenario: happy path
+    - Scenario: invalid/missing input
+    - Use `karate-config.js` base URL
+
+9. **Run** `mvn clean verify -Dspring.profiles.active=build` and report result.
+
+10. **Report**: files created/modified, curl examples for the new endpoint.
+
+## Constraints
+
+- No new dependencies unless essential (discuss first)
+- Do not change existing endpoint paths or response shapes
+- `CacheInfo.accoutnNumber` is a known typo — do not rename it
+- All tests must use `-Dspring.profiles.active=build` (no Redis required)

--- a/docs/runbooks/endpoint-smoke-test.md
+++ b/docs/runbooks/endpoint-smoke-test.md
@@ -1,0 +1,91 @@
+You are smoke-testing all endpoints of the locally running RedisCache-SpringBoot app.
+
+## Pre-flight check
+
+1. Verify the app is running:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/actuator/health
+   ```
+   If not 200, tell the user to start the app with `./SpringBootRunner.sh` and stop.
+
+## Smoke test matrix
+
+Run each curl in order. Use a shared test account number (e.g., `99901`).
+
+```bash
+BASE="http://localhost:8080"
+ACCT=99901
+
+# 1. Health check
+curl -s -w "\n[%{http_code}]" "$BASE/actuator/health"
+
+# 2. Add account (POST)
+curl -s -w "\n[%{http_code}]" -X POST "$BASE/Account/$ACCT" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"savings","value":"1000"}'
+
+# 3. Search account (POST /)
+curl -s -w "\n[%{http_code}]" -X POST "$BASE/" \
+  -H "Content-Type: application/json" \
+  -d "{\"account\":\"$ACCT\"}"
+
+# 4. Credit account (PATCH)
+curl -s -w "\n[%{http_code}]" -X PATCH "$BASE/Account/$ACCT" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"Credit","value":500}'
+
+# 5. Search again — verify value updated
+curl -s -w "\n[%{http_code}]" -X POST "$BASE/" \
+  -H "Content-Type: application/json" \
+  -d "{\"account\":\"$ACCT\"}"
+
+# 6. Withdraw (PATCH)
+curl -s -w "\n[%{http_code}]" -X PATCH "$BASE/Account/$ACCT" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"Withdraw","value":200}'
+
+# 7. Delete account
+curl -s -w "\n[%{http_code}]" -X DELETE "$BASE/Account/$ACCT" \
+  -H "Content-Type: application/json"
+
+# 8. Search after delete — expect empty/zeroed result
+curl -s -w "\n[%{http_code}]" -X POST "$BASE/" \
+  -H "Content-Type: application/json" \
+  -d "{\"account\":\"$ACCT\"}"
+
+# 9. Negative: add account with missing value field
+curl -s -w "\n[%{http_code}]" -X POST "$BASE/Account/$ACCT" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"savings"}'
+```
+
+## Expected results
+
+| # | Endpoint                     | Expected status | Key assertion                  |
+|---|------------------------------|-----------------|--------------------------------|
+| 1 | GET /actuator/health         | 200             | `{"status":"UP"}`              |
+| 2 | POST /Account/99901          | 200             | "Added into Data"              |
+| 3 | POST / (search)              | 200             | `value: 1000`, `type: savings` |
+| 4 | PATCH Credit                 | 200             | "is updated"                   |
+| 5 | POST / (search after credit) | 200             | `value: 1500`                  |
+| 6 | PATCH Withdraw               | 200             | "is updated"                   |
+| 7 | DELETE                       | 200             | "Removed Account"              |
+| 8 | POST / (search after delete) | 200             | `value: 0` or null fields      |
+| 9 | POST missing value           | 400             | validation error               |
+
+## Report format
+
+```
+Smoke Test Results — <timestamp>   App: localhost:8080
+────────────────────────────────────────────────────────
+ # │ Method  │ Path                   │ Status │ Result
+───┼─────────┼────────────────────────┼────────┼────────
+ 1 │ GET     │ /actuator/health       │ 200    │ ✅ PASS
+ 2 │ POST    │ /Account/99901         │ 200    │ ✅ PASS
+...
+────────────────────────────────────────────────────────
+Summary: X/9 passed
+```
+
+Flag any result where status or body does not match the expected table above.
+For failures, include the raw response body.

--- a/docs/runbooks/run-karate.md
+++ b/docs/runbooks/run-karate.md
@@ -1,0 +1,52 @@
+You are running and summarizing the Karate E2E test suite for RedisCache-SpringBoot.
+
+## Steps to execute
+
+1. **Run** the full Karate suite:
+   ```bash
+   mvn clean verify -Dspring.profiles.active=build 2>&1 | tee /tmp/karate-run.log
+   ```
+
+2. **Check exit code.** If non-zero, the suite has failures — proceed to step 4.
+
+3. **Parse results** from:
+    - `target/failsafe-reports/` — XML surefire/failsafe output
+    - `target/karate-reports/` — HTML/JSON Karate report (if present)
+    - `/tmp/karate-run.log` — raw Maven output
+
+4. **Summarize** in this format:
+
+   ```
+   Karate Results — <timestamp>
+   ─────────────────────────────
+   Scenarios : <total> | Passed: <n> | Failed: <n> | Skipped: <n>
+
+   PASSED:
+     ✅ account.feature / Add account to cache
+     ✅ account.feature / Update account – Credit
+     ...
+
+   FAILED:
+     ❌ search.feature / Search by account number
+        Request : POST / {"account":"12345"}
+        Expected: 200 {"account":"12345", ...}
+        Actual  : 500 {"error":"..."}
+        Log hint: <relevant log line>
+
+   Build: PASS | FAIL
+   ```
+
+5. **If failures exist:**
+    - Read the relevant `.feature` file to understand the scenario intent.
+    - Read the relevant service/controller code for the failing path.
+    - Diagnose the root cause (config issue, assertion mismatch, timing, etc.).
+    - Propose a fix with the exact file + line to change.
+    - Do NOT auto-apply fixes unless the user asks.
+
+6. **Report** the summary table to the user.
+
+## Constraints
+
+- Always use `-Dspring.profiles.active=build` — no external Redis required
+- Do not modify test code during this skill — diagnose only
+- If Maven is not on PATH, check `./mvnw` wrapper as fallback

--- a/pom.xml
+++ b/pom.xml
@@ -6,68 +6,139 @@
 
     <groupId>com.search</groupId>
     <artifactId>search-controller</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>war</packaging>
+    <version>1.1.0</version>
+    <packaging>jar</packaging>
 
-    <description>RedisCahe SpringBoot</description>
+    <description>RedisCache SpringBoot – modernized REST service with CI/CD and REST-MCP roadmap</description>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.2.RELEASE</version>
+        <version>3.4.5</version>
         <relativePath/>
     </parent>
 
     <properties>
-
-        <!-- Environment Properties -->
+        <java.version>17</java.version>
+        <!-- Active profile for local build/test (uses in-memory cache, no Redis needed) -->
         <spring.profiles.active>build</spring.profiles.active>
         <commonslang3.version>3.18.0</commonslang3.version>
-        <jedis.version>3.2.0</jedis.version>
-
+        <!-- Jedis 5.x is required for Spring Boot 3.x / Spring Data Redis 3.x -->
+        <jedis.version>5.2.0</jedis.version>
+        <karate.version>1.3.1</karate.version>
     </properties>
 
-
     <dependencies>
-        <!-- Spring Boot -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-        </dependency>
+        <!-- Spring Boot Web -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!--Spring -->
+        <!-- Bean Validation (jakarta namespace) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Actuator – health/info endpoints -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Redis -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${commonslang3.version}</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>${jedis.version}</version>
         </dependency>
+
+        <!-- Utilities -->
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
-            <scope>provided</scope>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commonslang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- ===== TEST ===== -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Karate – API/E2E testing -->
+        <dependency>
+            <groupId>com.intuit.karate</groupId>
+            <artifactId>karate-junit5</artifactId>
+            <version>${karate.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Unit tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>**/karate/**</exclude>
+                    </excludes>
+                    <systemPropertyVariables>
+                        <spring.profiles.active>build</spring.profiles.active>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+
+            <!-- Integration / E2E tests (Karate) – bound to verify phase -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/karate/*IT.java</include>
+                    </includes>
+                    <systemPropertyVariables>
+                        <spring.profiles.active>build</spring.profiles.active>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/search/CacheInfo.java
+++ b/src/main/java/com/search/CacheInfo.java
@@ -2,21 +2,18 @@ package com.search;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
 
 import java.io.Serializable;
 import java.time.Instant;
 
 @Data
-@Getter
-@Setter
 @AllArgsConstructor
 public class CacheInfo implements Serializable {
-    /* This class is Cache Data stored in Cache Bucket */
 
+    // Known typo kept intentionally – renaming breaks existing serialized cache entries
     private int accoutnNumber;
     private String type;
     private Long value;
-    Instant lastModification;
+    private Instant lastModification;
 }
+

--- a/src/main/java/com/search/CacheService.java
+++ b/src/main/java/com/search/CacheService.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 @Service(value = "CacheService")
 public class CacheService implements DataService {
 
-    private Cache cache;
+    private final Cache cache;
 
     public CacheService(Cache cache) {
         this.cache = cache;
@@ -20,25 +20,17 @@ public class CacheService implements DataService {
 
     @Override
     public void addDataToCache(int accountNumber, CacheData cacheData) throws Exception {
-
-        /* this will Add the account/CacheKey in Cache to store the value
-         * It will create the entry in Cache Buket */
-
         String cacheKey = "Account_" + accountNumber;
-        long value = Long.valueOf(cacheData.getValue());
-        if(retrieveByCacheKey(cacheKey) == null) {
-            cache.put(cacheKey, new CacheInfo(accountNumber,
-                    cacheData.getType(),
-                    value,
-                    Instant.now()));
+        long value = Long.parseLong(cacheData.getValue());
+        if (retrieveByCacheKey(cacheKey) == null) {
+            cache.put(cacheKey, new CacheInfo(accountNumber, cacheData.getType(), value, Instant.now()));
         }
     }
 
-
     @Override
     public void removeDataFromCache(int accountNumber) throws Exception {
-            String cacheKey = "Account_" + accountNumber;
-        if(retrieveByCacheKey(cacheKey) != null) {
+        String cacheKey = "Account_" + accountNumber;
+        if (retrieveByCacheKey(cacheKey) != null) {
             cache.evict(cacheKey);
         }
     }
@@ -46,58 +38,22 @@ public class CacheService implements DataService {
     @Override
     public void updateDataInCache(int accountNumber, PatchData patchData) throws Exception {
         String cacheKey = "Account_" + accountNumber;
+        Cache.ValueWrapper valueWrapper = cache.get(cacheKey);
+        if (valueWrapper == null) return;
+
+        CacheInfo cacheInfo = (CacheInfo) valueWrapper.get();
         switch (patchData.getAction()) {
-            case "Credit":
-
-                /* this will Increase the value in Cache stored values
-                 * And then add it back to Cache Data*/
-
-                if (cacheKey != null) {
-                    Cache.ValueWrapper valueWrapper = cache.get(cacheKey);
-                    if (valueWrapper != null) {
-                        CacheInfo cacheInfo =
-                                (CacheInfo) valueWrapper.get();
-                        long obj1 = cacheInfo.getValue();
-                        long obj2 = patchData.getValue();
-                        long sumOfValue = Long.sum(obj1, obj2);
-                        cacheInfo.setValue(sumOfValue);
-                    }
-                }
-                break;
-            case "Withdraw":
-
-                /* this will subtract the value from Cache stored values
-                * And then add it back to Cache Data*/
-
-                if (cacheKey != null) {
-                    Cache.ValueWrapper valueWrapper = cache.get(cacheKey);
-                    if (valueWrapper != null) {
-                        CacheInfo cacheInfo =
-                                (CacheInfo) valueWrapper.get();
-                        long obj1 = cacheInfo.getValue();
-                        long obj2 = patchData.getValue();
-                        long sumOfValue = Math.subtractExact(obj1, obj2);
-                        //if account balance goes less then 0 it will not value in cache will not update
-                        if (sumOfValue > 0){
-                            cacheInfo.setValue(sumOfValue);
-                        }else {
-                            cacheInfo.setValue(cacheInfo.getValue());
-                        }
-                    }
-                }
-                break;
-            case "Remove":
-
-                /* this will remove the account/CacheKey from Cache stored values */
-
-                if(retrieveByCacheKey(cacheKey) != null) {
-                    cache.evict(cacheKey);
-                }
+            case "Credit" -> cacheInfo.setValue(Long.sum(cacheInfo.getValue(), patchData.getValue()));
+            case "Withdraw" -> {
+                long result = Math.subtractExact(cacheInfo.getValue(), patchData.getValue());
+                // Floor at current balance; no overdraft
+                if (result > 0) cacheInfo.setValue(result);
+            }
+            case "Remove" -> cache.evict(cacheKey);
         }
     }
 
-
-    public Object retrieveByCacheKey(String cacheKey){
+    public Object retrieveByCacheKey(String cacheKey) {
         if (StringUtils.isNoneBlank(cacheKey)) {
             Cache.ValueWrapper wrapper = cache.get(cacheKey);
             if (wrapper != null) {
@@ -106,5 +62,5 @@ public class CacheService implements DataService {
         }
         return null;
     }
-
 }
+

--- a/src/main/java/com/search/SearchService.java
+++ b/src/main/java/com/search/SearchService.java
@@ -5,13 +5,10 @@ import com.search.api.Result;
 import com.search.api.Service;
 import org.springframework.cache.Cache;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @org.springframework.stereotype.Service("SearchService")
 public class SearchService implements Service {
 
-    private Cache cache;
+    private final Cache cache;
 
     public SearchService(Cache cache) {
         this.cache = cache;
@@ -19,14 +16,11 @@ public class SearchService implements Service {
 
     @Override
     public Result search(Request request) throws Exception {
-        String accountNumber = request.getAccount();
-        List cacheData = new ArrayList<>();
+        String cacheKey = "Account_" + request.getAccount();
         Result result = new Result();
-        String cacheKey = "Account_" + accountNumber;
         Cache.ValueWrapper valueWrapper = cache.get(cacheKey);
         if (valueWrapper != null) {
-            CacheInfo cacheInfo =
-                    (CacheInfo) valueWrapper.get();
+            CacheInfo cacheInfo = (CacheInfo) valueWrapper.get();
             result.setAccount(cacheInfo.getAccoutnNumber());
             result.setType(cacheInfo.getType());
             result.setValue(cacheInfo.getValue());
@@ -35,3 +29,4 @@ public class SearchService implements Service {
         return result;
     }
 }
+

--- a/src/main/java/com/search/api/CacheData.java
+++ b/src/main/java/com/search/api/CacheData.java
@@ -1,11 +1,14 @@
 package com.search.api;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+
 import java.io.Serializable;
 
 public class CacheData implements Serializable {
 
-    /* This class is POST Request or to add Data in Cache Bucket */
+    private String type;
+    @NotBlank
+    private String value;
 
     public String getType() {
         return type;
@@ -22,7 +25,5 @@ public class CacheData implements Serializable {
     public void setValue(String value) {
         this.value = value;
     }
-
-    private String type;
-    @NotNull private String value;
 }
+

--- a/src/main/java/com/search/api/DataController.java
+++ b/src/main/java/com/search/api/DataController.java
@@ -1,36 +1,41 @@
 package com.search.api;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @RestController
 public class DataController {
-    @Autowired private DataService dataService;
+
+    private final DataService dataService;
+
+    public DataController(DataService dataService) {
+        this.dataService = dataService;
+    }
 
     @PostMapping(value = "/Account/{accountNumber}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> addDataToCache(@Valid @RequestBody CacheData cacheData, @PathVariable("accountNumber") int accountNumber) throws Exception {
+    public ResponseEntity<?> addDataToCache(@Valid @RequestBody CacheData cacheData,
+                                            @PathVariable("accountNumber") int accountNumber) throws Exception {
         dataService.addDataToCache(accountNumber, cacheData);
-        return ResponseEntity.ok("Account " + accountNumber +" Added into Data" );
+        return ResponseEntity.ok("Account " + accountNumber + " Added into Data");
     }
 
     @PatchMapping(value = "/Account/{accountNumber}",
             consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> updateDataInCache(@PathVariable int accountNumber, @Valid @RequestBody PatchData patchData) throws Exception{
+    public ResponseEntity<?> updateDataInCache(@PathVariable int accountNumber,
+                                               @Valid @RequestBody PatchData patchData) throws Exception {
         dataService.updateDataInCache(accountNumber, patchData);
-        return ResponseEntity.ok("Account "+accountNumber+" is updated");
+        return ResponseEntity.ok("Account " + accountNumber + " is updated");
     }
 
-    @DeleteMapping(value = "/Account/{accountNumber}",
-            consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> removeDataFromCache(@PathVariable("accountNumber") int accountNumber) throws Exception{
+    @DeleteMapping(value = "/Account/{accountNumber}")
+    public ResponseEntity<?> removeDataFromCache(@PathVariable("accountNumber") int accountNumber) throws Exception {
         dataService.removeDataFromCache(accountNumber);
         return ResponseEntity.ok("Removed Account " + accountNumber);
     }
-
 }
+

--- a/src/main/java/com/search/api/PatchData.java
+++ b/src/main/java/com/search/api/PatchData.java
@@ -1,11 +1,14 @@
 package com.search.api;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+
 import java.io.Serializable;
 
 public class PatchData implements Serializable {
 
-    /* This class is Patch Request Data to store in Cache Bucket */
+    private Long value;
+    @NotBlank
+    private String action;
 
     public Long getValue() {
         return value;
@@ -22,9 +25,5 @@ public class PatchData implements Serializable {
     public void setAction(String action) {
         this.action = action;
     }
-
-    private Long value;
-
-    @NotNull
-    private String action;
 }
+

--- a/src/main/java/com/search/api/Request.java
+++ b/src/main/java/com/search/api/Request.java
@@ -1,8 +1,10 @@
 package com.search.api;
 
-public class Request {
+import java.io.Serializable;
 
-    /* request to search for account from cache and see the stored value in cache */
+public class Request implements Serializable {
+
+    private String account;
 
     public String getAccount() {
         return account;
@@ -11,6 +13,5 @@ public class Request {
     public void setAccount(String account) {
         this.account = account;
     }
-
-    private String account;
 }
+

--- a/src/main/java/com/search/api/Result.java
+++ b/src/main/java/com/search/api/Result.java
@@ -1,11 +1,14 @@
 package com.search.api;
 
-import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.Instant;
 
 public class Result implements Serializable {
 
+    private int account;
+    private String type;
+    private Long value;
+    private Instant lastModification;
 
     public int getAccount() {
         return account;
@@ -38,9 +41,5 @@ public class Result implements Serializable {
     public void setLastModification(Instant lastModification) {
         this.lastModification = lastModification;
     }
-
-    @NotNull private int account;
-    private String type;
-    @NotNull private Long value;
-    Instant lastModification;
 }
+

--- a/src/main/java/com/search/api/SearchController.java
+++ b/src/main/java/com/search/api/SearchController.java
@@ -1,25 +1,25 @@
 package com.search.api;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 public class SearchController {
 
-   @Autowired private Service service;
+    private final Service service;
 
-    public static final String APPLICATION_JSON_VALUE = "application/json";
+    public SearchController(Service service) {
+        this.service = service;
+    }
 
     @PostMapping(
             value = "/",
-            produces = APPLICATION_JSON_VALUE,
-            consumes = APPLICATION_JSON_VALUE
-    )
-    public Result search(@RequestBody Request request) throws Exception{
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public Result search(@RequestBody Request request) throws Exception {
         return service.search(request);
     }
 }
+

--- a/src/main/java/com/search/config/BuildCacheConfig.java
+++ b/src/main/java/com/search/config/BuildCacheConfig.java
@@ -9,13 +9,14 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @EnableCaching
-@Profile(value = {"build"})
+@Profile("build")
 public class BuildCacheConfig {
-    //This bean is Redis CacheManager for Managing different cache/Bucket.
+
     @Bean
-    public CacheManager cacheManager(){
+    public CacheManager cacheManager() {
         ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
         cacheManager.setCacheNames(CacheConfig.CACHE_LIST);
         return cacheManager;
     }
 }
+

--- a/src/main/java/com/search/config/CacheConfig.java
+++ b/src/main/java/com/search/config/CacheConfig.java
@@ -14,11 +14,12 @@ public class CacheConfig {
 
     public static final String ACCOUNT_CACHE = "AccountCache";
 
-    public static final List<String> CACHE_LIST = Collections.unmodifiableList(Arrays.asList(ACCOUNT_CACHE));
+    public static final List<String> CACHE_LIST =
+            Collections.unmodifiableList(Arrays.asList(ACCOUNT_CACHE));
 
-    //Cache Bucket
     @Bean(name = ACCOUNT_CACHE)
-    public Cache accountCache(CacheManager cacheManager){
+    public Cache accountCache(CacheManager cacheManager) {
         return cacheManager.getCache(ACCOUNT_CACHE);
     }
 }
+

--- a/src/main/java/com/search/config/RedisCacheConfig.java
+++ b/src/main/java/com/search/config/RedisCacheConfig.java
@@ -5,6 +5,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 @Configuration
 @EnableCaching
+@Profile("!build")
 public class RedisCacheConfig {
 
     @Value("${redis.url:localhost}")
@@ -25,7 +27,6 @@ public class RedisCacheConfig {
     @Value("${redis.port:6379}")
     private int redisPort;
 
-    //Config bean for Managing Redis/Jedis Serialized Cache data
     @Bean
     public JedisConnectionFactory redisConnectionFactory() {
         return new JedisConnectionFactory(new RedisStandaloneConfiguration(redisHostName, redisPort));
@@ -33,30 +34,18 @@ public class RedisCacheConfig {
 
     @Bean
     public CacheManager cacheManager(JedisConnectionFactory redisConnectionFactory) {
-        final RedisCacheConfiguration defaultCacheConfiguration =
-                RedisCacheConfiguration.defaultCacheConfig().disableCachingNullValues();
-        final Map<String, RedisCacheConfiguration> cacheConfigurationMap =
-                redisConfiguration(defaultCacheConfiguration);
-
+        RedisCacheConfiguration defaults = RedisCacheConfiguration.defaultCacheConfig().disableCachingNullValues();
         return RedisCacheManager.builder(redisConnectionFactory)
-                .withInitialCacheConfigurations(cacheConfigurationMap)
-                .cacheDefaults(defaultCacheConfiguration)
+                .withInitialCacheConfigurations(buildCacheConfig(defaults))
+                .cacheDefaults(defaults)
                 .disableCreateOnMissingCache()
                 .build();
-
     }
 
-    //This is Cache Config for Bucket
-    private Map<String, RedisCacheConfiguration> redisConfiguration(
-            RedisCacheConfiguration defaultCacheConfiguration) {
-        Map<String, RedisCacheConfiguration> redisCacheConfigurations = new HashMap<>();
-        //Data time to live in Cache Bucket.
-        //Currently set one Hour It for Account Cache
-        final RedisCacheConfiguration oneHour = defaultCacheConfiguration.entryTtl(Duration.ofHours(1));
-
-        redisCacheConfigurations.put(CacheConfig.ACCOUNT_CACHE, oneHour);
-
-        return Collections.unmodifiableMap(redisCacheConfigurations);
+    private Map<String, RedisCacheConfiguration> buildCacheConfig(RedisCacheConfiguration defaults) {
+        Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+        configs.put(CacheConfig.ACCOUNT_CACHE, defaults.entryTtl(Duration.ofHours(1)));
+        return Collections.unmodifiableMap(configs);
     }
-
 }
+

--- a/src/main/resources/application-build.properties
+++ b/src/main/resources/application-build.properties
@@ -1,0 +1,3 @@
+# Build profile – in-memory cache, no Redis connection
+# Disables the Redis health indicator so actuator/health stays UP without a live Redis server
+management.health.redis.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
-spring.redis.jedis.pool.max-idle=8
+server.port=8080
+# Redis connection (overridden by RedisCacheConfig beans; pool property kept for reference)
+spring.data.redis.jedis.pool.max-idle=8
+# Actuator
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always
+# Logging
+logging.level.com.search=INFO

--- a/src/main/test/RedisCache.postman_collection.json
+++ b/src/main/test/RedisCache.postman_collection.json
@@ -1,175 +1,175 @@
 {
-	"info": {
-		"_postman_id": "ef1cf3ea-6bf5-47f3-b64c-46c92bf73bfb",
-		"name": "RedisCache",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-	},
-	"item": [
-		{
-			"name": "ADD in Cache",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"type\":\"Saving\", \n\t\"value\":\"555\"\n}"
-				},
-				"url": {
-					"raw": "http://localhost:8080/Account/1234",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"Account",
-						"1234"
-					]
-				},
-				"description": "This End point will add data into RedisCahe."
-			},
-			"response": []
-		},
-		{
-			"name": "Remove from Cache",
-			"request": {
-				"method": "DELETE",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
-				"url": {
-					"raw": "http://localhost:8080/Account/1234",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"Account",
-						"1234"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "PATCH Update value",
-			"request": {
-				"method": "PATCH",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"action\":\"add\",\n\t\"value\":\"1000\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/Account/1234",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"Account",
-						"1234"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "PATCH Delete",
-			"request": {
-				"method": "PATCH",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"action\":\"delete\"\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:8080/Account/1234",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						"Account",
-						"1234"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Search from Cache",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"name": "Content-Type",
-						"value": "application/json",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n\t\"account\":\"1234\"\n}"
-				},
-				"url": {
-					"raw": "http://localhost:8080/",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "8080",
-					"path": [
-						""
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"protocolProfileBehavior": {}
+  "info": {
+    "_postman_id": "ef1cf3ea-6bf5-47f3-b64c-46c92bf73bfb",
+    "name": "RedisCache",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "ADD in Cache",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "name": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"type\":\"Saving\", \n\t\"value\":\"555\"\n}"
+        },
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
+          ]
+        },
+        "description": "This End point will add data into RedisCahe."
+      },
+      "response": []
+    },
+    {
+      "name": "Remove from Cache",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Content-Type",
+            "name": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": ""
+        },
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "PATCH Update value",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "name": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"action\":\"add\",\n\t\"value\":\"1000\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "PATCH Delete",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "name": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"action\":\"delete\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Search from Cache",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "name": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"account\":\"1234\"\n}"
+        },
+        "url": {
+          "raw": "http://localhost:8080/",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            ""
+          ]
+        }
+      },
+      "response": []
+    }
+  ],
+  "protocolProfileBehavior": {}
 }

--- a/src/test/java/com/search/CacheServiceTest.java
+++ b/src/test/java/com/search/CacheServiceTest.java
@@ -1,0 +1,122 @@
+package com.search;
+
+import com.search.api.CacheData;
+import com.search.api.PatchData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CacheServiceTest {
+
+    private Cache cache;
+    private CacheService cacheService;
+
+    @BeforeEach
+    void setUp() {
+        cache = new ConcurrentMapCache("AccountCache");
+        cacheService = new CacheService(cache);
+    }
+
+    @Test
+    void addDataToCache_storesEntry() throws Exception {
+        CacheData data = new CacheData();
+        data.setType("savings");
+        data.setValue("1000");
+
+        cacheService.addDataToCache(42, data);
+
+        assertNotNull(cacheService.retrieveByCacheKey("Account_42"));
+    }
+
+    @Test
+    void addDataToCache_doesNotOverwriteExistingEntry() throws Exception {
+        CacheData data = new CacheData();
+        data.setValue("1000");
+        cacheService.addDataToCache(1, data);
+
+        CacheData data2 = new CacheData();
+        data2.setValue("9999");
+        cacheService.addDataToCache(1, data2);
+
+        CacheInfo stored = (CacheInfo) cacheService.retrieveByCacheKey("Account_1");
+        assertEquals(1000L, stored.getValue());
+    }
+
+    @Test
+    void removeDataFromCache_evictsEntry() throws Exception {
+        CacheData data = new CacheData();
+        data.setValue("500");
+        cacheService.addDataToCache(10, data);
+
+        cacheService.removeDataFromCache(10);
+
+        assertNull(cacheService.retrieveByCacheKey("Account_10"));
+    }
+
+    @Test
+    void removeDataFromCache_nonExistentKey_doesNotThrow() {
+        assertDoesNotThrow(() -> cacheService.removeDataFromCache(9999));
+    }
+
+    @Test
+    void updateDataInCache_credit_increasesBalance() throws Exception {
+        CacheData data = new CacheData();
+        data.setValue("100");
+        cacheService.addDataToCache(5, data);
+
+        PatchData patch = new PatchData();
+        patch.setAction("Credit");
+        patch.setValue(50L);
+        cacheService.updateDataInCache(5, patch);
+
+        CacheInfo info = (CacheInfo) cacheService.retrieveByCacheKey("Account_5");
+        assertEquals(150L, info.getValue());
+    }
+
+    @Test
+    void updateDataInCache_withdraw_decreasesBalance() throws Exception {
+        CacheData data = new CacheData();
+        data.setValue("200");
+        cacheService.addDataToCache(6, data);
+
+        PatchData patch = new PatchData();
+        patch.setAction("Withdraw");
+        patch.setValue(75L);
+        cacheService.updateDataInCache(6, patch);
+
+        CacheInfo info = (CacheInfo) cacheService.retrieveByCacheKey("Account_6");
+        assertEquals(125L, info.getValue());
+    }
+
+    @Test
+    void updateDataInCache_withdraw_doesNotGoBelowZero() throws Exception {
+        CacheData data = new CacheData();
+        data.setValue("50");
+        cacheService.addDataToCache(7, data);
+
+        PatchData patch = new PatchData();
+        patch.setAction("Withdraw");
+        patch.setValue(200L);
+        cacheService.updateDataInCache(7, patch);
+
+        CacheInfo info = (CacheInfo) cacheService.retrieveByCacheKey("Account_7");
+        assertEquals(50L, info.getValue()); // unchanged
+    }
+
+    @Test
+    void updateDataInCache_remove_evictsEntry() throws Exception {
+        CacheData data = new CacheData();
+        data.setValue("300");
+        cacheService.addDataToCache(8, data);
+
+        PatchData patch = new PatchData();
+        patch.setAction("Remove");
+        patch.setValue(0L);
+        cacheService.updateDataInCache(8, patch);
+
+        assertNull(cacheService.retrieveByCacheKey("Account_8"));
+    }
+}

--- a/src/test/java/com/search/SearchServiceTest.java
+++ b/src/test/java/com/search/SearchServiceTest.java
@@ -1,0 +1,55 @@
+package com.search;
+
+import com.search.api.CacheData;
+import com.search.api.Request;
+import com.search.api.Result;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SearchServiceTest {
+
+    private Cache cache;
+    private CacheService cacheService;
+    private SearchService searchService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        cache = new ConcurrentMapCache("AccountCache");
+        cacheService = new CacheService(cache);
+        searchService = new SearchService(cache);
+
+        CacheData data = new CacheData();
+        data.setType("checking");
+        data.setValue("5000");
+        cacheService.addDataToCache(100, data);
+    }
+
+    @Test
+    void search_existingAccount_returnsResult() throws Exception {
+        Request req = new Request();
+        req.setAccount("100");
+
+        Result result = searchService.search(req);
+
+        assertEquals(100, result.getAccount());
+        assertEquals("checking", result.getType());
+        assertEquals(5000L, result.getValue());
+        assertNotNull(result.getLastModification());
+    }
+
+    @Test
+    void search_nonExistingAccount_returnsEmptyResult() throws Exception {
+        Request req = new Request();
+        req.setAccount("9999");
+
+        Result result = searchService.search(req);
+
+        assertNotNull(result);
+        assertEquals(0, result.getAccount()); // default int value
+        assertNull(result.getValue());
+    }
+}

--- a/src/test/java/com/search/api/DataControllerTest.java
+++ b/src/test/java/com/search/api/DataControllerTest.java
@@ -1,0 +1,80 @@
+package com.search.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("build")
+class DataControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void addAccount_success() throws Exception {
+        String body = """
+                {"type":"savings","value":"2500"}
+                """;
+        mockMvc.perform(post("/Account/200")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("200")));
+    }
+
+    @Test
+    void addAccount_missingValue_returnsBadRequest() throws Exception {
+        mockMvc.perform(post("/Account/201")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"type\":\"savings\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void patchAccount_credit() throws Exception {
+        // first create
+        mockMvc.perform(post("/Account/300")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"checking\",\"value\":\"1000\"}"));
+
+        mockMvc.perform(patch("/Account/300")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"action\":\"Credit\",\"value\":500}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("300")));
+    }
+
+    @Test
+    void patchAccount_missingAction_returnsBadRequest() throws Exception {
+        mockMvc.perform(patch("/Account/301")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"value\":100}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void deleteAccount_success() throws Exception {
+        // first create
+        mockMvc.perform(post("/Account/400")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"savings\",\"value\":\"800\"}"));
+
+        mockMvc.perform(delete("/Account/400")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("400")));
+    }
+}

--- a/src/test/java/com/search/api/SearchControllerTest.java
+++ b/src/test/java/com/search/api/SearchControllerTest.java
@@ -1,0 +1,53 @@
+package com.search.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("build")
+class SearchControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void search_unknownAccount_returnsOkWithEmptyResult() throws Exception {
+        mockMvc.perform(post("/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"account\":\"99999\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void search_existingAccount_returnsData() throws Exception {
+        // Seed data first
+        mockMvc.perform(post("/Account/500")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"type\":\"savings\",\"value\":\"3000\"}"));
+
+        mockMvc.perform(post("/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"account\":\"500\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.account").value(500))
+                .andExpect(jsonPath("$.type").value("savings"))
+                .andExpect(jsonPath("$.value").value(3000));
+    }
+
+    @Test
+    void search_missingBody_returnsBadRequest() throws Exception {
+        mockMvc.perform(post("/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(""))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/search/karate/KarateRunnerIT.java
+++ b/src/test/java/com/search/karate/KarateRunnerIT.java
@@ -1,0 +1,24 @@
+package com.search.karate;
+
+import com.intuit.karate.junit5.Karate;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Karate E2E runner – boots the full Spring context on a fixed port, then runs
+ * all feature files under src/test/resources/karate.
+ * <p>
+ * Run with: mvn failsafe:integration-test
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
+        properties = {"server.port=8090"})
+@ActiveProfiles("build")
+class KarateRunnerIT {
+
+    @Karate.Test
+    Karate testAll() {
+        return Karate.run("classpath:karate").relativeTo(getClass());
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,2 @@
+spring.profiles.active=build
+server.port=0

--- a/src/test/resources/karate-config.js
+++ b/src/test/resources/karate-config.js
@@ -1,0 +1,7 @@
+// karate-config.js – shared configuration injected into every feature
+function fn() {
+    var config = {
+        baseUrl: 'http://localhost:8090'
+    };
+    return config;
+}

--- a/src/test/resources/karate/account.feature
+++ b/src/test/resources/karate/account.feature
@@ -1,0 +1,84 @@
+Feature: Account Cache API – CRUD flows
+
+  Background:
+    * url baseUrl
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # POST /Account/{accountNumber} – create / add to cache
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  Scenario: Add a new account to cache (happy path)
+    Given path '/Account/1001'
+    And request { type: 'savings', value: '5000' }
+    When method POST
+    Then status 200
+    And match response contains '1001'
+
+  Scenario: Add account – duplicate should not overwrite (idempotent)
+    Given path '/Account/1002'
+    And request { type: 'savings', value: '1000' }
+    When method POST
+    Then status 200
+    # Second POST with different value – cache should still hold original
+    Given path '/Account/1002'
+    And request { type: 'savings', value: '9999' }
+    When method POST
+    Then status 200
+
+  Scenario: Add account – missing required field 'value' returns 400
+    Given path '/Account/1003'
+    And request { type: 'savings' }
+    When method POST
+    Then status 400
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # PATCH /Account/{accountNumber} – update value in cache
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  Scenario: Credit an existing account
+    # Seed
+    Given path '/Account/2001'
+    And request { type: 'checking', value: '2000' }
+    When method POST
+    Then status 200
+    # Credit
+    Given path '/Account/2001'
+    And request { action: 'Credit', value: 500 }
+    When method PATCH
+    Then status 200
+    And match response contains '2001'
+
+  Scenario: Withdraw from an existing account
+    Given path '/Account/2002'
+    And request { type: 'checking', value: '1000' }
+    When method POST
+    Then status 200
+    Given path '/Account/2002'
+    And request { action: 'Withdraw', value: 300 }
+    When method PATCH
+    Then status 200
+
+  Scenario: Patch account – missing required field 'action' returns 400
+    Given path '/Account/2003'
+    And request { value: 100 }
+    When method PATCH
+    Then status 400
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # DELETE /Account/{accountNumber} – remove from cache
+  # ─────────────────────────────────────────────────────────────────────────────
+
+  Scenario: Delete an existing account
+    Given path '/Account/3001'
+    And request { type: 'savings', value: '750' }
+    When method POST
+    Then status 200
+    Given path '/Account/3001'
+    When method DELETE
+    Then status 200
+    And match response contains '3001'
+
+  Scenario: Delete a non-existent account returns 200 (no-op)
+    Given path '/Account/3999'
+    When method DELETE
+    Then status 200

--- a/src/test/resources/karate/search.feature
+++ b/src/test/resources/karate/search.feature
@@ -1,0 +1,46 @@
+Feature: Search API – cache lookup flows
+
+  Background:
+    * url baseUrl
+
+  Scenario: Search returns data for a seeded account
+    # Seed
+    Given path '/Account/4001'
+    And request { type: 'investment', value: '10000' }
+    When method POST
+    Then status 200
+    # Search
+    Given path '/'
+    And request { account: '4001' }
+    When method POST
+    Then status 200
+    And match response.account == 4001
+    And match response.type == 'investment'
+    And match response.value == 10000
+
+  Scenario: Search unknown account returns 200 with empty/default result
+    Given path '/'
+    And request { account: '99999' }
+    When method POST
+    Then status 200
+    And match response.value == '#null'
+
+  Scenario: Search after delete returns empty result
+    Given path '/Account/4002'
+    And request { type: 'savings', value: '500' }
+    When method POST
+    Then status 200
+    Given path '/Account/4002'
+    When method DELETE
+    Then status 200
+    Given path '/'
+    And request { account: '4002' }
+    When method POST
+    Then status 200
+    And match response.value == '#null'
+
+  Scenario: Health endpoint is reachable
+    Given url baseUrl + '/actuator/health'
+    When method GET
+    Then status 200
+    And match response.status == 'UP'


### PR DESCRIPTION
- Upgrade to Spring Boot 3.4.5 (Java 17) and Jedis 5.2.0
- Switch application packaging from WAR to JAR
- Migrate from `javax.validation` to `jakarta.validation`
- Refactor codebase to use constructor injection and modern switch expressions
- Add unit test suite for controllers and services using JUnit 5 and MockMvc
- Add Karate E2E testing framework with dedicated feature scenarios
- Implement GitHub Actions workflows for CI build/test, E2E gate, and versioned releases
- Introduce comprehensive documentation including AI agent instructions (`AGENTS.md`), system state docs, and runbooks
- Improve local development script (`SpringBootRunner.sh`) and refine `.gitignore`