### PR TITLE
Add REST-MCP Bridge (Phases 1-4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Environment variables for RedisCache-SpringBoot
+# Copy this file to .env and fill in values for your local environment.
+# .env is git-ignored and must never be committed.
+
+# ─── Spring profile ───────────────────────────────────────────────────────────
+# Use 'build' for local dev (in-memory cache, no Redis required)
+# Use 'redis' or any other name for a real Redis instance
+SPRING_PROFILES_ACTIVE=build
+
+# ─── Server ───────────────────────────────────────────────────────────────────
+SERVER_PORT=8080
+
+# ─── Redis (only needed when SPRING_PROFILES_ACTIVE != build) ─────────────────
+REDIS_URL=localhost
+REDIS_PORT=6379
+
+# ─── MCP auth (Phase 3 — leave blank until write tools are enabled) ───────────
+MCP_AUTH_API_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ Sample Spring Boot 3.4.5 + Redis cache service demonstrating the **Walmart Turin
 turn any backend REST repo into an MCP-capable service so AI agents can call it directly
 via the Model Context Protocol — without breaking existing REST consumers.
 
-Current state: REST baseline is production-ready (v1.1.0). Active work is Phase 1 of the
-REST-MCP bridge (see `docs/REST-MCP-ROADMAP.md`).
+Current state: REST-MCP bridge is **fully implemented** (v1.2.0). All four MCP phases are
+complete. See `docs/REST-MCP-ROADMAP.md` for the versioning policy and `one-requirement.md`
+for the full checklist.
 
 ---
 
@@ -49,13 +50,16 @@ for local runs — without it the app tries to connect to a real Redis instance.
 
 ## Endpoint Matrix
 
-| Method | Path                       | Controller         | Service method        | Notes                                   |
-|--------|----------------------------|--------------------|-----------------------|-----------------------------------------|
-| POST   | `/Account/{accountNumber}` | `DataController`   | `addDataToCache`      | Idempotent — no-op if key exists        |
-| PATCH  | `/Account/{accountNumber}` | `DataController`   | `updateDataInCache`   | Actions: `Credit`, `Withdraw`, `Remove` |
-| DELETE | `/Account/{accountNumber}` | `DataController`   | `removeDataFromCache` | Evicts key; no-op if missing            |
-| POST   | `/`                        | `SearchController` | `search`              | Cache miss returns zeroed `Result`      |
-| GET    | `/actuator/health`         | Spring Actuator    | —                     | Always UP in build profile              |
+| Method | Path                       | Controller         | Service method        | Notes                                    |
+|--------|----------------------------|--------------------|-----------------------|------------------------------------------|
+| POST   | `/Account/{accountNumber}` | `DataController`   | `addDataToCache`      | Idempotent — no-op if key exists         |
+| PATCH  | `/Account/{accountNumber}` | `DataController`   | `updateDataInCache`   | Actions: `Credit`, `Withdraw`, `Remove`  |
+| DELETE | `/Account/{accountNumber}` | `DataController`   | `removeDataFromCache` | Evicts key; no-op if missing             |
+| POST   | `/`                        | `SearchController` | `search`              | Cache miss returns zeroed `Result`       |
+| GET    | `/actuator/health`         | Spring Actuator    | —                     | Always UP in build profile               |
+| GET    | `/actuator/info`           | Spring Actuator    | `McpInfoContributor`  | Lists MCP tools under `mcp.tools`        |
+| GET    | `/mcp/sse`                 | MCP SDK            | —                     | SSE transport — MCP client connects here |
+| POST   | `/mcp/message`             | MCP SDK            | —                     | MCP JSON-RPC messages; auth-gated        |
 
 ---
 
@@ -87,6 +91,14 @@ src/main/java/com/search/
 │   ├── CacheConfig.java         ← profile-switched cache bean factory
 │   ├── BuildCacheConfig.java    ← ConcurrentMapCache (build/test profile)
 │   ├── RedisCacheConfig.java    ← JedisConnectionFactory (prod profile)
+├── mcp/
+│   ├── McpConfig.java           ← McpSyncServer + WebMvcSseServerTransportProvider beans
+│   ├── McpToolAdapter.java      ← interface for auto-wiring tool specs
+│   ├── Tool.java                ← @Tool annotation (name, description, inputSchema, version)
+│   ├── AccountSearchTool.java   ← searchAccount + getAccountBalance read tools
+│   ├── AccountWriteTool.java    ← creditAccount + withdrawAccount + deleteAccount write tools
+│   ├── McpInfoContributor.java  ← /actuator/info lists all tools + version
+│   └── McpAuthFilter.java       ← X-MCP-API-Key guard + Accept-MCP-Version negotiation
 ├── CacheService.java            ← implements DataService + Service
 ├── SearchService.java           ← thin search façade (delegates to CacheService)
 └── SearchApplication.java
@@ -108,19 +120,20 @@ src/main/java/com/search/
 
 ## When You Expose a Service Method as an MCP Tool (Turing Pattern)
 
-This is the active Phase 1 work. Follow the pattern in `docs/REST-MCP-ROADMAP.md`:
+MCP bridge is **complete** (v1.2.0). The pattern is established — follow it when adding new tools:
 
-1. **Read-only first.** Start with `searchAccount` / `getAccountBalance` — no auth needed.
-2. **Adapter class** goes in `src/main/java/com/search/mcp/` (create the package).
+1. **Read-only first.** Add to `AccountSearchTool`; write tools go in `AccountWriteTool`.
+2. **Adapter class** lives in `src/main/java/com/search/mcp/`.
 3. **Never modify existing service signatures.** The MCP adapter calls services; services
    do not know about MCP.
 4. **Tool schema** must have: `name` (camelCase), `description` (≥ 1 sentence), `inputSchema`
    matching the service method parameters.
-5. **Contract test required** — add an MCP client integration test alongside unit tests.
-6. **REST endpoint stays unchanged** — verify with existing Karate suite after adding MCP layer.
+5. **Implement `McpToolAdapter`** — add the `SyncToolSpecification` to `toolSpecs()`.
+   `McpConfig` auto-wires all `McpToolAdapter` beans.
+6. **Contract test required** — add unit tests in `src/test/.../mcp/` and extend `McpIntegrationIT`.
+7. **REST endpoint stays unchanged** — verify with existing Karate suite after adding MCP layer.
 
-Recommended SDK: `io.modelcontextprotocol:sdk` (pinned version). See roadmap Phase 2 task list
-for dependency coordinates.
+SDK: `io.modelcontextprotocol.sdk:mcp-spring-webmvc:0.9.0` (pinned in `pom.xml`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,124 @@
+# Changelog
+
+All notable changes to this project are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning follows [SemVer](https://semver.org/).
+
+---
+
+## [Unreleased]
+
+---
+
+## [1.2.0] — 2026-05-28
+
+### Added — REST-MCP Bridge (Phases 1–4)
+
+**MCP Layer**
+
+- `McpConfig` — registers `WebMvcSseServerTransportProvider` + `McpSyncServer`; exposes `/mcp/sse` (SSE) and
+  `/mcp/message` (JSON-RPC) endpoints
+- `McpToolAdapter` — interface for auto-wiring tool specs into `McpSyncServer`
+- `@Tool` annotation — retained for future annotation processing; runtime registration uses `McpToolAdapter.toolSpecs()`
+- `AccountSearchTool` — `searchAccount` and `getAccountBalance` read tools; delegates to `SearchService`
+- `AccountWriteTool` — `creditAccount`, `withdrawAccount`, `deleteAccount` write tools; delegates to `CacheService`;
+  structured audit log on every call
+- `McpInfoContributor` — contributes tool inventory to `GET /actuator/info` under `mcp.tools`
+- `McpAuthFilter` — API-key guard (`X-MCP-API-Key` header); version negotiation (`Accept-MCP-Version`); adds
+  `x-mcp-version: 1` to all `/mcp/**` responses; disabled when `mcp.auth.api-key` is empty
+
+**Tests (23 new)**
+
+- `AccountSearchToolTest` (4) — searchAccount hit/miss; getAccountBalance hit/miss
+- `AccountWriteToolTest` (5) — credit, withdraw, no-overdraft, delete, invalid-account error path
+- `McpRateLimiterTest` (2) — token-bucket consume + refill behavior
+- `McpAuthFilterTest` (9) — missing/wrong key → 401; valid key passes; unsupported version → 400; version defaults;
+  response header; no-auth when unconfigured; non-MCP path bypassed; 11th write call → 429
+- `McpInfoContributorTest` (2) — `/actuator/info` lists tools + version field
+- `McpIntegrationIT` (5) — full MCP protocol via `McpSyncClient`: list tools, searchAccount miss/hit, getAccountBalance
+  hit; REST info endpoint
+
+**Docs**
+
+- `docs/REST-MCP-ROADMAP.md` — Phase 4 versioning policy updated: v0 sunset documented, 90-day deprecation window
+  defined
+- `one-requirement.md` — all T1.1–T4.4 checkboxes ticked; Deliverables + Milestones tables updated
+- `application.properties` — `mcp.auth.api-key=` (empty = auth disabled locally)
+
+### Notes
+
+- **REST endpoints unchanged** — additive MCP layer only
+- Auth is opt-in: set `mcp.auth.api-key` env var to enable the API-key guard
+- `McpSyncServer` bean uses `destroyMethod = "close"` for clean JVM shutdown
+
+### Rollback
+
+- Remove `src/main/java/com/search/mcp/` package and `mcp-spring-webmvc` from `pom.xml`
+- REST endpoints, CI, and release pipeline are unaffected
+
+---
+
+## [1.1.0] — 2026-05-28
+
+### Added
+
+- Spring Boot upgrade: 2.2.2 → 3.4.5 (Java 17)
+- Karate E2E test suite (`account.feature`, `search.feature`) — 12 scenarios
+- GitHub Actions CI: `ci.yml`, `e2e.yml`, `release.yml` (E2E-gated release)
+- Spring Boot Actuator with `/actuator/health` endpoint
+- `spring-boot-starter-validation` (jakarta namespace)
+- `AGENTS.md` — AI agent instructions and conventions
+- `docs/CURRENT-STATE.md` — endpoint inventory and DTO map
+- `docs/REST-MCP-ROADMAP.md` — phased MCP migration plan
+- `docs/runbooks/` — 5 operational runbooks
+- `application-build.properties` — disables Redis health indicator in build profile
+
+### Changed
+
+- `javax.validation` → `jakarta.validation` across all DTOs
+- WAR → JAR packaging
+- `jedis` 3.2.0 → 5.2.0 (Spring Data Redis 3.x compatibility)
+- `SpringBootRunner.sh` hardened with `set -euo pipefail`, Java 17 guard, clear output
+- `spring.redis.*` → `spring.data.redis.*` properties
+- `@Profile(value = {"build"})` simplified to `@Profile("build")`
+- `@Profile` added to `RedisCacheConfig` (`"!build"`) to prevent bean conflict
+- Constructor injection replaces `@Autowired` field injection in controllers
+- Removed redundant `@Getter`/`@Setter` from `CacheInfo` (covered by `@Data`)
+- `switch` in `CacheService` refactored to arrow-switch (Java 17)
+- `Long.valueOf` → `Long.parseLong` in `CacheService`
+- `DELETE /Account/{n}` — removed `consumes = APPLICATION_JSON` constraint
+- `SearchController` — replaced local constant with `MediaType.APPLICATION_JSON_VALUE`
+
+### Fixed
+
+- Dead code: `if (cacheKey != null)` guard inside switch (cacheKey always non-null)
+- Unused `List`/`ArrayList` imports and dead variable in `SearchService`
+- Stale `@NotNull` on `int account` and `Long value` in `Result` (response DTO)
+- `@NotNull` → `@NotBlank` on String-typed validation fields (`CacheData.value`, `PatchData.action`)
+- Postman collection: corrected action names to match implementation (`Credit`, `Withdraw`, `Remove`)
+
+### Removed
+
+- Redundant `spring-boot-starter` and `spring-web` dependencies (covered by `spring-boot-starter-web`)
+- Duplicate `lombok` dependency declaration
+- Version pin on Lombok (now managed by Spring Boot BOM)
+
+### Rollback Notes
+
+> If v1.1.0 causes issues, revert to v1.0-SNAPSHOT by checking out the last commit before
+> this release. Key breaking changes from the upgrade:
+> - Java 17 is required; the app will not start on Java 8 or 11
+> - `javax.*` imports replaced by `jakarta.*` — cannot run on old servlet containers
+> - Packaging is JAR not WAR — deploy with `java -jar`, not a servlet container
+> - `application.properties` keys changed: `spring.redis.*` → `spring.data.redis.*`
+
+---
+
+## [1.0-SNAPSHOT] — 2019 (original)
+
+### Initial state
+
+- Spring Boot 2.2.2, Java 8, WAR packaging
+- Redis cache with Jedis 3.2.0
+- `DataController` (POST/PATCH/DELETE `/Account/{n}`) and `SearchController` (POST `/`)
+- In-memory fallback via `BuildCacheConfig` (`build` profile)

--- a/docs/runbooks/release-gate-check.md
+++ b/docs/runbooks/release-gate-check.md
@@ -1,0 +1,78 @@
+You are performing a pre-release gate check for RedisCache-SpringBoot.
+A release is only allowed when ALL gates below are green.
+
+## Steps to execute
+
+### Gate 1 – CI Status
+
+```bash
+# Check latest CI run on main
+gh run list --branch main --limit 5 --json status,conclusion,name,createdAt \
+  --jq '.[] | "\(.name) | \(.status) | \(.conclusion) | \(.createdAt)"'
+```
+
+- ✅ PASS: latest run for CI workflow is `completed / success`
+- ❌ FAIL: any `failure` or `in_progress` → STOP, report the failing job
+
+### Gate 2 – E2E (Karate) locally green
+
+```bash
+mvn clean verify -Dspring.profiles.active=build 2>&1 | tail -20
+```
+
+- ✅ PASS: `BUILD SUCCESS`, no Karate failures
+- ❌ FAIL: → STOP, report failing scenarios
+
+### Gate 3 – No uncommitted changes
+
+```bash
+git status --porcelain
+```
+
+- ✅ PASS: empty output
+- ❌ FAIL: list dirty files and stop
+
+### Gate 4 – Version bump
+
+1. Read current version in `pom.xml` (line with `<version>`).
+2. Check existing tags: `git tag --sort=-v:refname | head -5`
+3. Confirm the `pom.xml` version is HIGHER than the latest tag.
+4. Confirm version follows SemVer (`MAJOR.MINOR.PATCH`).
+
+- ✅ PASS: version is new and valid
+- ❌ FAIL: same version already tagged → ask user for new version
+
+### Gate 5 – Release notes
+
+Check if there is a release notes entry or changelog for this version:
+
+- Look for a `CHANGELOG.md` or a release notes section in `README.md`.
+- If missing, generate a draft from `git log <last-tag>..HEAD --oneline`.
+
+## Output
+
+If ALL gates pass, output the exact commands to release:
+
+```bash
+# Tag the release
+git tag -a v<VERSION> -m "Release v<VERSION>
+
+<summary of changes from git log>
+
+# Push tag (triggers release workflow)
+git push origin v<VERSION>
+```
+
+Then remind the user:
+
+- The `release.yml` workflow will fire automatically on tag push.
+- Monitor with: `gh run list --branch v<VERSION> --limit 3`
+
+If ANY gate fails, stop after the first failure and report clearly:
+
+```
+❌ Gate <N> FAILED — <reason>
+Action required: <what to fix>
+```
+
+Do NOT push or tag if any gate is red.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.search</groupId>
     <artifactId>search-controller</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <description>RedisCache SpringBoot – modernized REST service with CI/CD and REST-MCP roadmap</description>
@@ -70,7 +70,12 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- ===== TEST ===== -->
+        <!-- MCP SDK – lightweight JSON-RPC transport for MCP tool exposure (Phase 1+) -->
+        <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-spring-webmvc</artifactId>
+            <version>0.9.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -105,6 +110,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>**/*Tests.java</include>
@@ -123,8 +129,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
                     <includes>
                         <include>**/karate/*IT.java</include>
+                        <include>**/mcp/*IT.java</include>
                     </includes>
                     <systemPropertyVariables>
                         <spring.profiles.active>build</spring.profiles.active>

--- a/src/main/java/com/search/SearchApplication.java
+++ b/src/main/java/com/search/SearchApplication.java
@@ -2,8 +2,10 @@ package com.search;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SearchApplication {
     public static void main(String[] args) {
         SpringApplication.run(SearchApplication.class, args);

--- a/src/main/java/com/search/mcp/AccountSearchTool.java
+++ b/src/main/java/com/search/mcp/AccountSearchTool.java
@@ -1,0 +1,83 @@
+package com.search.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.search.SearchService;
+import com.search.api.Request;
+import com.search.api.Result;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AccountSearchTool implements McpToolAdapter {
+
+    private static final String SEARCH_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"," +
+                    "\"description\":\"Account number to search\"}},\"required\":[\"account\"]}";
+
+    private static final String BALANCE_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"," +
+                    "\"description\":\"Account number\"}},\"required\":[\"account\"]}";
+
+    private final SearchService searchService;
+    private final ObjectMapper objectMapper;
+
+    public AccountSearchTool(SearchService searchService, ObjectMapper objectMapper) {
+        this.searchService = searchService;
+        this.objectMapper = objectMapper;
+    }
+
+    public Result searchAccount(String account) throws Exception {
+        Request req = new Request();
+        req.setAccount(account);
+        return searchService.search(req);
+    }
+
+    public Long getAccountBalance(String account) throws Exception {
+        Request req = new Request();
+        req.setAccount(account);
+        return searchService.search(req).getValue();
+    }
+
+    @Override
+    public List<McpServerFeatures.SyncToolSpecification> toolSpecs() {
+        return List.of(
+                new McpServerFeatures.SyncToolSpecification(
+                        new McpSchema.Tool(
+                                "searchAccount",
+                                "Search account cache by account number. Returns type, value, and last modification timestamp.",
+                                SEARCH_SCHEMA),
+                        this::handleSearchAccount
+                ),
+                new McpServerFeatures.SyncToolSpecification(
+                        new McpSchema.Tool(
+                                "getAccountBalance",
+                                "Get current balance for an account number from the cache.",
+                                BALANCE_SCHEMA),
+                        this::handleGetAccountBalance
+                )
+        );
+    }
+
+    private McpSchema.CallToolResult handleSearchAccount(McpSyncServerExchange exchange, Map<String, Object> args) {
+        try {
+            Result result = searchAccount((String) args.get("account"));
+            return new McpSchema.CallToolResult(objectMapper.writeValueAsString(result), false);
+        } catch (Exception e) {
+            return new McpSchema.CallToolResult(e.getMessage(), true);
+        }
+    }
+
+    private McpSchema.CallToolResult handleGetAccountBalance(McpSyncServerExchange exchange, Map<String, Object> args) {
+        try {
+            Long balance = getAccountBalance((String) args.get("account"));
+            return new McpSchema.CallToolResult(balance != null ? balance.toString() : "null", false);
+        } catch (Exception e) {
+            return new McpSchema.CallToolResult(e.getMessage(), true);
+        }
+    }
+}

--- a/src/main/java/com/search/mcp/AccountWriteTool.java
+++ b/src/main/java/com/search/mcp/AccountWriteTool.java
@@ -1,0 +1,122 @@
+package com.search.mcp;
+
+import com.search.CacheService;
+import com.search.api.PatchData;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class AccountWriteTool implements McpToolAdapter {
+
+    private static final Logger log = LoggerFactory.getLogger(AccountWriteTool.class);
+
+    private static final String ACCOUNT_AMOUNT_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"}," +
+                    "\"amount\":{\"type\":\"number\"}},\"required\":[\"account\",\"amount\"]}";
+
+    private static final String ACCOUNT_SCHEMA =
+            "{\"type\":\"object\",\"properties\":{\"account\":{\"type\":\"string\"}}," +
+                    "\"required\":[\"account\"]}";
+
+    private final CacheService cacheService;
+
+    public AccountWriteTool(CacheService cacheService) {
+        this.cacheService = cacheService;
+    }
+
+    public void creditAccount(String account, long amount) throws Exception {
+        log.info("tool=creditAccount account={} action=Credit timestamp={}", account, Instant.now());
+        PatchData patch = new PatchData();
+        patch.setAction("Credit");
+        patch.setValue(amount);
+        cacheService.updateDataInCache(parseAccount(account), patch);
+    }
+
+    public void withdrawAccount(String account, long amount) throws Exception {
+        log.info("tool=withdrawAccount account={} action=Withdraw timestamp={}", account, Instant.now());
+        PatchData patch = new PatchData();
+        patch.setAction("Withdraw");
+        patch.setValue(amount);
+        cacheService.updateDataInCache(parseAccount(account), patch);
+    }
+
+    public void deleteAccount(String account) throws Exception {
+        log.info("tool=deleteAccount account={} action=Delete timestamp={}", account, Instant.now());
+        cacheService.removeDataFromCache(parseAccount(account));
+    }
+
+    @Override
+    public List<McpServerFeatures.SyncToolSpecification> toolSpecs() {
+        return List.of(
+                new McpServerFeatures.SyncToolSpecification(
+                        new McpSchema.Tool(
+                                "creditAccount",
+                                "Credit an amount to an account. Write operation — requires X-MCP-API-Key header.",
+                                ACCOUNT_AMOUNT_SCHEMA),
+                        this::handleCredit
+                ),
+                new McpServerFeatures.SyncToolSpecification(
+                        new McpSchema.Tool(
+                                "withdrawAccount",
+                                "Withdraw an amount from an account. Cannot go below zero. Write operation — requires X-MCP-API-Key header.",
+                                ACCOUNT_AMOUNT_SCHEMA),
+                        this::handleWithdraw
+                ),
+                new McpServerFeatures.SyncToolSpecification(
+                        new McpSchema.Tool(
+                                "deleteAccount",
+                                "Delete an account from the cache. Write operation — requires X-MCP-API-Key header.",
+                                ACCOUNT_SCHEMA),
+                        this::handleDelete
+                )
+        );
+    }
+
+    private McpSchema.CallToolResult handleCredit(McpSyncServerExchange exchange, Map<String, Object> args) {
+        try {
+            String account = (String) args.get("account");
+            long amount = ((Number) args.get("amount")).longValue();
+            creditAccount(account, amount);
+            return new McpSchema.CallToolResult("credited " + amount + " to account " + account, false);
+        } catch (Exception e) {
+            return new McpSchema.CallToolResult(e.getMessage(), true);
+        }
+    }
+
+    private McpSchema.CallToolResult handleWithdraw(McpSyncServerExchange exchange, Map<String, Object> args) {
+        try {
+            String account = (String) args.get("account");
+            long amount = ((Number) args.get("amount")).longValue();
+            withdrawAccount(account, amount);
+            return new McpSchema.CallToolResult("withdrew " + amount + " from account " + account, false);
+        } catch (Exception e) {
+            return new McpSchema.CallToolResult(e.getMessage(), true);
+        }
+    }
+
+    private McpSchema.CallToolResult handleDelete(McpSyncServerExchange exchange, Map<String, Object> args) {
+        try {
+            String account = (String) args.get("account");
+            deleteAccount(account);
+            return new McpSchema.CallToolResult("deleted account " + account, false);
+        } catch (Exception e) {
+            return new McpSchema.CallToolResult(e.getMessage(), true);
+        }
+    }
+
+    private int parseAccount(String account) {
+        try {
+            return Integer.parseInt(account);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid account number: '" + account + "' — must be numeric");
+        }
+    }
+}

--- a/src/main/java/com/search/mcp/McpAuthFilter.java
+++ b/src/main/java/com/search/mcp/McpAuthFilter.java
@@ -1,0 +1,71 @@
+package com.search.mcp;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class McpAuthFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(McpAuthFilter.class);
+    private static final List<String> SUPPORTED_VERSIONS = List.of("1");
+
+    private final String configuredApiKey;
+    private final McpRateLimiter rateLimiter;
+
+    public McpAuthFilter(@Value("${mcp.auth.api-key:}") String configuredApiKey, McpRateLimiter rateLimiter) {
+        this.configuredApiKey = configuredApiKey;
+        this.rateLimiter = rateLimiter;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/mcp/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain chain) throws ServletException, IOException {
+        response.setHeader("x-mcp-version", "1");
+
+        String requestedVersion = request.getHeader("Accept-MCP-Version");
+        if (requestedVersion == null) {
+            log.warn("Accept-MCP-Version header missing — defaulting to v1 (pre-versioning request)");
+        } else if (!SUPPORTED_VERSIONS.contains(requestedVersion)) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"unsupported_version\",\"supported\":[\"1\"]}");
+            return;
+        }
+
+        if (StringUtils.isNotBlank(configuredApiKey)) {
+            String providedKey = request.getHeader("X-MCP-API-Key");
+            if (!configuredApiKey.equals(providedKey)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return;
+            }
+        }
+
+        if (StringUtils.isNotBlank(configuredApiKey)
+                && "POST".equalsIgnoreCase(request.getMethod())
+                && "/mcp/message".equals(request.getRequestURI())
+                && !rateLimiter.tryConsume(request.getRemoteAddr())) {
+            response.setStatus(429);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"error\":\"rate_limit_exceeded\",\"retry_after_seconds\":60}");
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/search/mcp/McpConfig.java
+++ b/src/main/java/com/search/mcp/McpConfig.java
@@ -1,0 +1,45 @@
+package com.search.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Configuration
+public class McpConfig {
+
+    @Bean
+    public WebMvcSseServerTransportProvider mcpTransportProvider(ObjectMapper objectMapper) {
+        return new WebMvcSseServerTransportProvider(objectMapper, "/mcp/message", "/mcp/sse");
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> mcpRouterFunction(WebMvcSseServerTransportProvider transportProvider) {
+        return transportProvider.getRouterFunction();
+    }
+
+    @Bean(destroyMethod = "close")
+    public McpSyncServer mcpSyncServer(WebMvcSseServerTransportProvider transportProvider,
+                                       List<McpToolAdapter> adapters) {
+        List<McpServerFeatures.SyncToolSpecification> allTools = adapters.stream()
+                .flatMap(a -> a.toolSpecs().stream())
+                .collect(Collectors.toList());
+
+        return McpServer.sync(transportProvider)
+                .serverInfo("account-search-service", "1.2.0")
+                // tools(false) = tool list is static; no tools/list_changed notifications sent.
+                // Change to tools(true) and call mcpServer.notifyToolsListChanged() if tools become dynamic.
+                .capabilities(McpSchema.ServerCapabilities.builder().tools(false).build())
+                .tools(allTools)
+                .build();
+    }
+}

--- a/src/main/java/com/search/mcp/McpInfoContributor.java
+++ b/src/main/java/com/search/mcp/McpInfoContributor.java
@@ -1,0 +1,44 @@
+package com.search.mcp;
+
+import org.springframework.boot.actuate.info.Info;
+import org.springframework.boot.actuate.info.InfoContributor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class McpInfoContributor implements InfoContributor {
+
+    private final ApplicationContext applicationContext;
+    private volatile List<Map<String, String>> cachedTools;
+
+    public McpInfoContributor(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public synchronized void contribute(Info.Builder builder) {
+        if (cachedTools == null) {
+            cachedTools = discoverTools();
+        }
+        builder.withDetail("mcp", Map.of("tools", cachedTools));
+    }
+
+    private List<Map<String, String>> discoverTools() {
+        List<Map<String, String>> tools = new ArrayList<>();
+        applicationContext.getBeansOfType(McpToolAdapter.class).values().forEach(adapter ->
+                adapter.toolSpecs().forEach(spec -> {
+                    Map<String, String> info = new LinkedHashMap<>();
+                    info.put("name", spec.tool().name());
+                    info.put("description", spec.tool().description());
+                    info.put("version", "1");
+                    tools.add(info);
+                })
+        );
+        return tools;
+    }
+}

--- a/src/main/java/com/search/mcp/McpRateLimiter.java
+++ b/src/main/java/com/search/mcp/McpRateLimiter.java
@@ -1,0 +1,45 @@
+package com.search.mcp;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Component
+public class McpRateLimiter {
+
+    private final int writesPerMinute;
+    private final ConcurrentHashMap<String, AtomicLong> buckets = new ConcurrentHashMap<>();
+
+    public McpRateLimiter(@Value("${mcp.rate-limit.writes-per-minute:10}") int writesPerMinute) {
+        this.writesPerMinute = writesPerMinute;
+    }
+
+    public boolean tryConsume(String clientIp) {
+        if (writesPerMinute <= 0) {
+            return true;
+        }
+        String key = (clientIp == null || clientIp.isBlank()) ? "unknown" : clientIp;
+        AtomicLong tokens = buckets.computeIfAbsent(key, ignored -> new AtomicLong(writesPerMinute));
+
+        while (true) {
+            long current = tokens.get();
+            if (current <= 0) {
+                return false;
+            }
+            if (tokens.compareAndSet(current, current - 1)) {
+                return true;
+            }
+        }
+    }
+
+    @Scheduled(fixedRate = 60_000)
+    public void refillBuckets() {
+        if (writesPerMinute <= 0) {
+            return;
+        }
+        buckets.forEach((ip, bucket) -> bucket.set(writesPerMinute));
+    }
+}

--- a/src/main/java/com/search/mcp/McpToolAdapter.java
+++ b/src/main/java/com/search/mcp/McpToolAdapter.java
@@ -1,0 +1,9 @@
+package com.search.mcp;
+
+import io.modelcontextprotocol.server.McpServerFeatures;
+
+import java.util.List;
+
+public interface McpToolAdapter {
+    List<McpServerFeatures.SyncToolSpecification> toolSpecs();
+}

--- a/src/main/java/com/search/mcp/Tool.java
+++ b/src/main/java/com/search/mcp/Tool.java
@@ -1,0 +1,19 @@
+package com.search.mcp;
+
+import java.lang.annotation.*;
+
+/**
+ * Reserved for future annotation processor; runtime uses {@link McpToolAdapter#toolSpecs()}.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Tool {
+    String name();
+
+    String description();
+
+    String inputSchema() default "{}";
+
+    int version() default 1;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,5 +4,9 @@ spring.data.redis.jedis.pool.max-idle=8
 # Actuator
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always
+# MCP auth – set to a non-empty value to enable API-key guard on /mcp/** endpoints
+mcp.auth.api-key=
+# MCP write-tool rate limit per client IP (calls per minute, 0 = unlimited)
+mcp.rate-limit.writes-per-minute=10
 # Logging
 logging.level.com.search=INFO

--- a/src/main/test/RedisCache.postman_collection.json
+++ b/src/main/test/RedisCache.postman_collection.json
@@ -1,88 +1,45 @@
 {
   "info": {
     "_postman_id": "ef1cf3ea-6bf5-47f3-b64c-46c92bf73bfb",
-    "name": "RedisCache",
+    "name": "RedisCache v1.1.0",
+    "description": "Manual smoke-test collection for RedisCache-SpringBoot. Start the app with ./SpringBootRunner.sh before running.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
     {
-      "name": "ADD in Cache",
+      "name": "Health Check",
       "request": {
-        "method": "POST",
-        "header": [
-          {
-            "key": "Content-Type",
-            "name": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n\t\"type\":\"Saving\", \n\t\"value\":\"555\"\n}"
-        },
+        "method": "GET",
+        "header": [],
         "url": {
-          "raw": "http://localhost:8080/Account/1234",
+          "raw": "http://localhost:8080/actuator/health",
           "protocol": "http",
           "host": [
             "localhost"
           ],
           "port": "8080",
           "path": [
-            "Account",
-            "1234"
-          ]
-        },
-        "description": "This End point will add data into RedisCahe."
-      },
-      "response": []
-    },
-    {
-      "name": "Remove from Cache",
-      "request": {
-        "method": "DELETE",
-        "header": [
-          {
-            "key": "Content-Type",
-            "name": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": ""
-        },
-        "url": {
-          "raw": "http://localhost:8080/Account/1234",
-          "protocol": "http",
-          "host": [
-            "localhost"
-          ],
-          "port": "8080",
-          "path": [
-            "Account",
-            "1234"
+            "actuator",
+            "health"
           ]
         }
       },
       "response": []
     },
     {
-      "name": "PATCH Update value",
+      "name": "Add Account to Cache",
       "request": {
-        "method": "PATCH",
+        "method": "POST",
         "header": [
           {
             "key": "Content-Type",
-            "name": "Content-Type",
             "value": "application/json",
             "type": "text"
           }
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n\t\"action\":\"add\",\n\t\"value\":\"1000\"\n}",
+          "raw": "{\n\t\"type\": \"savings\",\n\t\"value\": \"1000\"\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -105,56 +62,24 @@
       "response": []
     },
     {
-      "name": "PATCH Delete",
-      "request": {
-        "method": "PATCH",
-        "header": [
-          {
-            "key": "Content-Type",
-            "name": "Content-Type",
-            "value": "application/json",
-            "type": "text"
-          }
-        ],
-        "body": {
-          "mode": "raw",
-          "raw": "{\n\t\"action\":\"delete\"\n}",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
-        "url": {
-          "raw": "http://localhost:8080/Account/1234",
-          "protocol": "http",
-          "host": [
-            "localhost"
-          ],
-          "port": "8080",
-          "path": [
-            "Account",
-            "1234"
-          ]
-        }
-      },
-      "response": []
-    },
-    {
-      "name": "Search from Cache",
+      "name": "Search Account from Cache",
       "request": {
         "method": "POST",
         "header": [
           {
             "key": "Content-Type",
-            "name": "Content-Type",
             "value": "application/json",
             "type": "text"
           }
         ],
         "body": {
           "mode": "raw",
-          "raw": "{\n\t\"account\":\"1234\"\n}"
+          "raw": "{\n\t\"account\": \"1234\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
         },
         "url": {
           "raw": "http://localhost:8080/",
@@ -165,6 +90,131 @@
           "port": "8080",
           "path": [
             ""
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Credit Account (PATCH)",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"action\": \"Credit\",\n\t\"value\": 500\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Withdraw from Account (PATCH)",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"action\": \"Withdraw\",\n\t\"value\": 200\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Remove via PATCH action",
+      "request": {
+        "method": "PATCH",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"action\": \"Remove\",\n\t\"value\": 0\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Delete Account from Cache",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8080/Account/1234",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8080",
+          "path": [
+            "Account",
+            "1234"
           ]
         }
       },

--- a/src/test/java/com/search/mcp/AccountSearchToolTest.java
+++ b/src/test/java/com/search/mcp/AccountSearchToolTest.java
@@ -1,0 +1,74 @@
+package com.search.mcp;
+
+import com.search.SearchService;
+import com.search.api.Request;
+import com.search.api.Result;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@ActiveProfiles("build")
+class AccountSearchToolTest {
+
+    @Autowired
+    AccountSearchTool tool;
+
+    @MockitoBean
+    SearchService searchService;
+
+    @Test
+    void searchAccount_hit_returnsResult() throws Exception {
+        Result expected = new Result();
+        expected.setAccount(12345);
+        expected.setType("savings");
+        expected.setValue(1000L);
+        expected.setLastModification(Instant.now());
+        when(searchService.search(any(Request.class))).thenReturn(expected);
+
+        Result actual = tool.searchAccount("12345");
+
+        assertThat(actual.getAccount()).isEqualTo(12345);
+        assertThat(actual.getType()).isEqualTo("savings");
+        assertThat(actual.getValue()).isEqualTo(1000L);
+    }
+
+    @Test
+    void searchAccount_miss_returnsEmptyResult() throws Exception {
+        when(searchService.search(any(Request.class))).thenReturn(new Result());
+
+        Result actual = tool.searchAccount("99999");
+
+        assertThat(actual.getAccount()).isZero();
+        assertThat(actual.getValue()).isNull();
+        assertThat(actual.getType()).isNull();
+    }
+
+    @Test
+    void getAccountBalance_hit_returnsValue() throws Exception {
+        Result result = new Result();
+        result.setValue(2500L);
+        when(searchService.search(any(Request.class))).thenReturn(result);
+
+        Long balance = tool.getAccountBalance("12345");
+
+        assertThat(balance).isEqualTo(2500L);
+    }
+
+    @Test
+    void getAccountBalance_miss_returnsNull() throws Exception {
+        when(searchService.search(any(Request.class))).thenReturn(new Result());
+
+        Long balance = tool.getAccountBalance("99999");
+
+        assertThat(balance).isNull();
+    }
+}

--- a/src/test/java/com/search/mcp/AccountWriteToolTest.java
+++ b/src/test/java/com/search/mcp/AccountWriteToolTest.java
@@ -1,0 +1,99 @@
+package com.search.mcp;
+
+import com.search.CacheService;
+import com.search.SearchService;
+import com.search.api.CacheData;
+import com.search.api.Request;
+import com.search.api.Result;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("build")
+class AccountWriteToolTest {
+
+    private static final int ACCOUNT = 77001;
+    private static final String ACCOUNT_STR = "77001";
+    @Autowired
+    AccountWriteTool writeTool;
+    @Autowired
+    CacheService cacheService;
+    @Autowired
+    SearchService searchService;
+
+    @BeforeEach
+    void setup() throws Exception {
+        cacheService.removeDataFromCache(ACCOUNT);
+        CacheData data = new CacheData();
+        data.setType("savings");
+        data.setValue("1000");
+        cacheService.addDataToCache(ACCOUNT, data);
+    }
+
+    @Test
+    void creditAccount_increasesBalance() throws Exception {
+        writeTool.creditAccount(ACCOUNT_STR, 500L);
+
+        Result result = searchService.search(request(ACCOUNT_STR));
+
+        assertThat(result.getValue()).isEqualTo(1500L);
+    }
+
+    @Test
+    void withdrawAccount_decreasesBalance() throws Exception {
+        writeTool.withdrawAccount(ACCOUNT_STR, 200L);
+
+        Result result = searchService.search(request(ACCOUNT_STR));
+
+        assertThat(result.getValue()).isEqualTo(800L);
+    }
+
+    @Test
+    void withdrawAccount_doesNotGoBelowZero() throws Exception {
+        writeTool.withdrawAccount(ACCOUNT_STR, 5000L);
+
+        Result result = searchService.search(request(ACCOUNT_STR));
+
+        assertThat(result.getValue()).isEqualTo(1000L);
+    }
+
+    @Test
+    void deleteAccount_evictsKey() throws Exception {
+        writeTool.deleteAccount(ACCOUNT_STR);
+
+        Result result = searchService.search(request(ACCOUNT_STR));
+
+        assertThat(result.getValue()).isNull();
+        assertThat(result.getType()).isNull();
+    }
+
+    @Test
+    void handleCredit_invalidAccount_returnsHelpfulError() throws Exception {
+        Method handler = AccountWriteTool.class.getDeclaredMethod(
+                "handleCredit", McpSyncServerExchange.class, Map.class);
+        handler.setAccessible(true);
+
+        McpSchema.CallToolResult result = (McpSchema.CallToolResult) handler.invoke(
+                writeTool, null, Map.of("account", "not-a-number", "amount", 100));
+
+        assertThat(result.isError()).isTrue();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertThat(text).contains("Invalid account number");
+    }
+
+    private Request request(String account) {
+        Request req = new Request();
+        req.setAccount(account);
+        return req;
+    }
+}

--- a/src/test/java/com/search/mcp/McpAuthFilterTest.java
+++ b/src/test/java/com/search/mcp/McpAuthFilterTest.java
@@ -1,0 +1,143 @@
+package com.search.mcp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpAuthFilterTest {
+
+    private McpAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new McpAuthFilter("secret-key", new McpRateLimiter(10));
+    }
+
+    @Test
+    void missingApiKey_returns401() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        req.addHeader("Accept-MCP-Version", "1");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, new MockFilterChain());
+
+        assertThat(res.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void wrongApiKey_returns401() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        req.addHeader("Accept-MCP-Version", "1");
+        req.addHeader("X-MCP-API-Key", "wrong-key");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, new MockFilterChain());
+
+        assertThat(res.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void validApiKey_requestProceeds() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        req.addHeader("Accept-MCP-Version", "1");
+        req.addHeader("X-MCP-API-Key", "secret-key");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(200);
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    @Test
+    void unsupportedVersion_returns400() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        req.addHeader("Accept-MCP-Version", "99");
+        req.addHeader("X-MCP-API-Key", "secret-key");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, new MockFilterChain());
+
+        assertThat(res.getStatus()).isEqualTo(400);
+        assertThat(res.getContentAsString()).contains("unsupported_version");
+    }
+
+    @Test
+    void missingVersionHeader_defaultsToV1AndProceeds() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        req.addHeader("X-MCP-API-Key", "secret-key");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(res.getStatus()).isEqualTo(200);
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    @Test
+    void responseContainsVersionHeader() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        req.addHeader("Accept-MCP-Version", "1");
+        req.addHeader("X-MCP-API-Key", "secret-key");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        filter.doFilter(req, res, new MockFilterChain());
+
+        assertThat(res.getHeader("x-mcp-version")).isEqualTo("1");
+    }
+
+    @Test
+    void noAuthRequired_whenKeyNotConfigured() throws Exception {
+        McpAuthFilter noAuthFilter = new McpAuthFilter("", new McpRateLimiter(10));
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        noAuthFilter.doFilter(req, res, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    @Test
+    void nonMcpPath_isNotFiltered() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest("GET", "/actuator/health");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(req, res, chain);
+
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    @Test
+    void eleventhWriteCall_returns429() throws Exception {
+        McpAuthFilter limitedFilter = new McpAuthFilter("secret-key", new McpRateLimiter(10));
+
+        for (int i = 0; i < 10; i++) {
+            MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+            req.setRemoteAddr("10.10.10.10");
+            req.addHeader("Accept-MCP-Version", "1");
+            req.addHeader("X-MCP-API-Key", "secret-key");
+            MockHttpServletResponse res = new MockHttpServletResponse();
+            limitedFilter.doFilter(req, res, new MockFilterChain());
+            assertThat(res.getStatus()).isEqualTo(200);
+        }
+
+        MockHttpServletRequest req = new MockHttpServletRequest("POST", "/mcp/message");
+        req.setRemoteAddr("10.10.10.10");
+        req.addHeader("Accept-MCP-Version", "1");
+        req.addHeader("X-MCP-API-Key", "secret-key");
+        MockHttpServletResponse res = new MockHttpServletResponse();
+
+        limitedFilter.doFilter(req, res, new MockFilterChain());
+
+        assertThat(res.getStatus()).isEqualTo(429);
+        assertThat(res.getContentAsString()).contains("rate_limit_exceeded");
+    }
+}

--- a/src/test/java/com/search/mcp/McpInfoContributorTest.java
+++ b/src/test/java/com/search/mcp/McpInfoContributorTest.java
@@ -1,0 +1,36 @@
+package com.search.mcp;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("build")
+class McpInfoContributorTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void actuatorInfo_containsSearchAndBalanceTools() throws Exception {
+        mockMvc.perform(get("/actuator/info"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mcp.tools[?(@.name == 'searchAccount')]").exists())
+                .andExpect(jsonPath("$.mcp.tools[?(@.name == 'getAccountBalance')]").exists());
+    }
+
+    @Test
+    void actuatorInfo_toolsHaveVersionField() throws Exception {
+        mockMvc.perform(get("/actuator/info"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mcp.tools[0].version").value("1"));
+    }
+}

--- a/src/test/java/com/search/mcp/McpIntegrationIT.java
+++ b/src/test/java/com/search/mcp/McpIntegrationIT.java
@@ -1,0 +1,120 @@
+package com.search.mcp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.search.CacheService;
+import com.search.api.CacheData;
+import io.modelcontextprotocol.client.McpClient;
+import io.modelcontextprotocol.client.McpSyncClient;
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("build")
+class McpIntegrationIT {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Autowired
+    CacheService cacheService;
+
+    private McpSyncClient mcpClient;
+
+    @BeforeEach
+    void setUpMcpClient() {
+        HttpClientSseClientTransport transport = new HttpClientSseClientTransport(
+                HttpClient.newBuilder(),
+                "http://localhost:" + port,
+                "/mcp/sse",
+                new ObjectMapper()
+        );
+        mcpClient = McpClient.sync(transport)
+                .requestTimeout(Duration.ofSeconds(30))
+                .build();
+        mcpClient.initialize();
+    }
+
+    @AfterEach
+    void tearDownMcpClient() {
+        if (mcpClient != null) {
+            mcpClient.close();
+        }
+    }
+
+    @Test
+    void actuatorInfo_listsBothReadTools() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/info", String.class);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).contains("searchAccount").contains("getAccountBalance");
+    }
+
+    @Test
+    void mcpListTools_returnsBothReadTools() {
+        McpSchema.ListToolsResult result = mcpClient.listTools();
+
+        assertThat(result.tools())
+                .extracting(McpSchema.Tool::name)
+                .contains("searchAccount", "getAccountBalance");
+    }
+
+    @Test
+    void mcpCallSearchAccount_cacheMiss_returnsZeroedResult() {
+        McpSchema.CallToolResult result = mcpClient.callTool(
+                new McpSchema.CallToolRequest("searchAccount", Map.of("account", "00000")));
+
+        assertThat(result.isError()).isFalse();
+        assertThat(result.content()).isNotEmpty();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertThat(text).contains("\"account\"");
+    }
+
+    @Test
+    void mcpCallSearchAccount_cacheHit_returnsResult() throws Exception {
+        CacheData data = new CacheData();
+        data.setType("checking");
+        data.setValue("5000");
+        cacheService.addDataToCache(55001, data);
+
+        McpSchema.CallToolResult result = mcpClient.callTool(
+                new McpSchema.CallToolRequest("searchAccount", Map.of("account", "55001")));
+
+        assertThat(result.isError()).isFalse();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertThat(text).contains("\"account\"").contains("55001");
+    }
+
+    @Test
+    void mcpCallGetAccountBalance_cacheHit_returnsBalance() throws Exception {
+        CacheData data = new CacheData();
+        data.setType("savings");
+        data.setValue("9000");
+        cacheService.addDataToCache(55002, data);
+
+        McpSchema.CallToolResult result = mcpClient.callTool(
+                new McpSchema.CallToolRequest("getAccountBalance", Map.of("account", "55002")));
+
+        assertThat(result.isError()).isFalse();
+        String text = ((McpSchema.TextContent) result.content().get(0)).text();
+        assertThat(text).isEqualTo("9000");
+    }
+}

--- a/src/test/java/com/search/mcp/McpRateLimiterTest.java
+++ b/src/test/java/com/search/mcp/McpRateLimiterTest.java
@@ -1,0 +1,30 @@
+package com.search.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpRateLimiterTest {
+
+    @Test
+    void limitTwo_allowsTwoThenDeniesThird() {
+        McpRateLimiter limiter = new McpRateLimiter(2);
+
+        assertThat(limiter.tryConsume("1.1.1.1")).isTrue();
+        assertThat(limiter.tryConsume("1.1.1.1")).isTrue();
+        assertThat(limiter.tryConsume("1.1.1.1")).isFalse();
+    }
+
+    @Test
+    void refillTick_replenishesTokens() {
+        McpRateLimiter limiter = new McpRateLimiter(2);
+
+        limiter.tryConsume("2.2.2.2");
+        limiter.tryConsume("2.2.2.2");
+        assertThat(limiter.tryConsume("2.2.2.2")).isFalse();
+
+        limiter.refillBuckets();
+
+        assertThat(limiter.tryConsume("2.2.2.2")).isTrue();
+    }
+}


### PR DESCRIPTION
- Integrate `mcp-spring-webmvc` SDK and configure MCP Sync Server via `McpConfig`.
- Implement read (`AccountSearchTool`) and write (`AccountWriteTool`) MCP tools.
- Add `McpAuthFilter` for API key authentication and version negotiation.
- Add `McpRateLimiter` for MCP write operations.
- Add `McpInfoContributor` to expose MCP tools via the `/actuator/info` endpoint.
- Add unit and integration tests for all new MCP components.
- Enable scheduling in `SearchApplication` for the rate limiter bucket refill.
- Bump project version to 1.2.0, update `CHANGELOG.md`, and add `.env.example` and runbook documentation.