### PR TITLE
Add documentation for REST-MCP bridge and update README for v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,104 @@
 # RedisCache-SpringBoot
 
-Spring Boot 3.4.5 + Redis cache service — modernized REST API with CI/CD and a REST-MCP Northstar roadmap.
+Spring Boot 3.4.5 service that stores account data in a cache and supports both:
+1. **REST clients** (stable existing endpoints)
+2. **MCP clients** (AI-agent tool calls over `/mcp/**`)
 
-> **Current version:** `1.1.0` &nbsp;|&nbsp; **Java:** 17 &nbsp;|&nbsp; **Profile:** `build` (in-memory cache, no Redis
-> needed for tests)
+> **Current version:** `1.2.0` &nbsp;|&nbsp; **Java:** 17 &nbsp;|&nbsp; **Default local profile:** `build` (in-memory cache, no Redis required)
 
 ---
 
-## Quick Start
+## What this project demonstrates
+
+This repo shows a practical migration pattern:
+
+- Keep the Java service contract stable
+- Add Redis-backed caching for production
+- Keep local/test runs fast with in-memory cache
+- Expose the same business capabilities as MCP tools (additive, non-breaking)
+
+---
+
+## How we converted the Java application to Redis-backed caching
+
+### Before → After
+
+| Area | Before (legacy baseline) | After (current state) |
+|------|---------------------------|------------------------|
+| Runtime | Older Spring Boot generation | Spring Boot `3.4.5` + Java `17` |
+| Validation | `javax.*` | `jakarta.*` |
+| Packaging | WAR-oriented | Runnable JAR |
+| Cache backend | Ad-hoc/legacy setup | Spring Cache + profile-based backend |
+| Production cache | Not standardized | Redis via `RedisCacheManager` + Jedis |
+| Local/test cache | Mixed local setups | `build` profile with `ConcurrentMapCacheManager` |
+| Release safety | Limited automation | Unit + Karate E2E + CI gates |
+
+### Key implementation choices
+
+1. **Single cache contract:** `CacheConfig` defines one cache name: `AccountCache`.
+2. **Profile-based cache backend:**  
+   - `BuildCacheConfig` (`@Profile("build")`) uses in-memory `ConcurrentMapCacheManager`.  
+   - `RedisCacheConfig` (`@Profile("!build")`) uses Redis with `JedisConnectionFactory`.
+3. **Production TTL policy:** `AccountCache` entries expire after **1 hour** in Redis.
+4. **Zero REST contract breakage:** Controllers and endpoint paths stayed stable while internals were modernized.
+5. **Safe rollout path:** Test profile defaults to in-memory cache so CI/local runs are deterministic without external Redis.
+
+For the full migration narrative (files touched, rationale, and verification approach), see:
+`docs/JAVA-APP-TO-REDIS-CONVERSION.md`.
+
+---
+
+## Quick start
 
 ```bash
-# No Redis required — uses in-memory cache
+# Run locally without Redis (in-memory cache)
 ./SpringBootRunner.sh
 
-# Unit tests
+# Unit tests (build profile)
 mvn clean test -Dspring.profiles.active=build
 
-# Full E2E (Karate)
+# Full verification (unit + integration + Karate)
 mvn clean verify -Dspring.profiles.active=build
 ```
 
-## About the Service
+---
 
-In-memory / Redis-backed cache for account data. Uses `CacheManager` (profile-switched: in-memory for `build`, Jedis for
-production) to manage an `AccountCache` bucket with 1-hour TTL.
+## Run with real Redis
 
-### Endpoints
+```bash
+# Start Redis (example)
+redis-server --port 6379
 
-| Method | Path                       | Description                                       |
-|--------|----------------------------|---------------------------------------------------|
-| POST   | `/Account/{accountNumber}` | Add account to cache                              |
-| PATCH  | `/Account/{accountNumber}` | Update account (`Credit` / `Withdraw` / `Remove`) |
-| DELETE | `/Account/{accountNumber}` | Evict account from cache                          |
-| POST   | `/`                        | Search account by number                          |
-| GET    | `/actuator/health`         | Health check                                      |
-
-### Add account
-
-```
-POST /Account/1234
-Content-Type: application/json
-
-{ "type": "Saving", "value": "100" }
-
-→ 200  "Account 1234 Added into Data"
+# Run app with non-build profile so RedisCacheConfig is active
+mvn spring-boot:run -Dspring-boot.run.profiles=redis \
+  -Dspring-boot.run.arguments="--redis.url=localhost --redis.port=6379"
 ```
 
-### Search account
-
-```
-POST /
-Content-Type: application/json
-
-{ "account": "1234" }
-
-→ 200
-{
-  "account": 1234,
-  "type": "Saving",
-  "value": 100,
-  "lastModification": "2024-12-20T02:40:24.312Z"
-}
-```
-
-### Update (Credit / Withdraw)
-
-```
-PATCH /Account/1234
-Content-Type: application/json
-
-{ "action": "Credit", "value": 200 }
-
-→ 200  "Account 1234 is updated"
-```
-
-### Delete
-
-```
-DELETE /Account/1234
-
-→ 200  "Removed Account 1234"
-```
+When not using the `build` profile, the app wires `RedisCacheConfig` and stores cache entries in Redis.
 
 ---
 
-## Architecture
+## API surface
 
-See `AGENTS.md` for full source layout, conventions, and MCP roadmap guidance.  
-See `docs/REST-MCP-ROADMAP.md` for the phased plan toward REST-MCP bridge.
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/Account/{accountNumber}` | Add account if missing |
+| PATCH | `/Account/{accountNumber}` | `Credit` / `Withdraw` / `Remove` |
+| DELETE | `/Account/{accountNumber}` | Remove account |
+| POST | `/` | Search account |
+| GET | `/actuator/health` | Health endpoint |
+| GET | `/actuator/info` | Service + MCP tool inventory |
+| GET | `/mcp/sse` | MCP SSE transport |
+| POST | `/mcp/message` | MCP JSON-RPC endpoint |
 
-## Prerequisites (production with Redis)
+---
 
-- Java 17+
-- Maven 3.8+
-- Redis 7+ on `localhost:6379` (only needed for `redis` profile)
+## Documentation map
+
+- `docs/JAVA-APP-TO-REDIS-CONVERSION.md` — complete migration story (Java app → Redis-backed service)
+- `docs/CURRENT-STATE.md` — endpoint/DTO/current behavior snapshot
+- `docs/REST-MCP-ROADMAP.md` — MCP phase history and versioning policy
+- `one-requirement.md` — full acceptance criteria and delivery checklist
+- `AGENTS.md` — contributor/agent engineering conventions
 
 Contact: skullfox@hackermail.com


### PR DESCRIPTION
Adds comprehensive documentation for the completed REST-MCP bridge feature (v1.2.0) and updates the repository README to reflect the new state.

Specific changes:
- Added `one-requirement.md` detailing the full requirements, architecture, and developer task checklists for the MCP integration.
- Added `docs/REST-MCP-ROADMAP.md` outlining the finalized project phases, deliverables, and versioning policy.
- Added `docs/runbooks/scaffold-mcp-tool.md` to guide the scaffolding of new MCP tools.
- Updated `README.md` to reflect version 1.2.0, highlight dual REST and MCP client support, summarize the Redis cache modernization, and refresh the API endpoint table and documentation map.